### PR TITLE
Refactor implicit copy modules to include more configurable helm variables

### DIFF
--- a/manager/apis/motion/v1alpha1/streamtransfer_webhook.go
+++ b/manager/apis/motion/v1alpha1/streamtransfer_webhook.go
@@ -69,7 +69,7 @@ func (r *StreamTransfer) Default() {
 	}
 
 	if r.Spec.ReadDataType == "" {
-		r.Spec.ReadDataType = ChangeData
+		r.Spec.ReadDataType = LogData
 	}
 
 	if r.Spec.WriteDataType == "" {

--- a/manager/apis/motion/v1alpha1/streamtransfer_webhook.go
+++ b/manager/apis/motion/v1alpha1/streamtransfer_webhook.go
@@ -69,7 +69,7 @@ func (r *StreamTransfer) Default() {
 	}
 
 	if r.Spec.ReadDataType == "" {
-		r.Spec.ReadDataType = LogData
+		r.Spec.ReadDataType = ChangeData
 	}
 
 	if r.Spec.WriteDataType == "" {

--- a/modules/fybrik-implicit-copy-batch/templates/batchtransfer.yaml
+++ b/modules/fybrik-implicit-copy-batch/templates/batchtransfer.yaml
@@ -80,3 +80,6 @@ spec:
   imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
   {{ end }}
   noFinalizer: {{ .Values.noFinalizer }}
+  readDataType: {{ .Values.readDataType | quote}}
+  writeDataType: {{ .Values.writeDataType | quote }}
+  writeOperation: {{ .Values.writeOperation | quote }}

--- a/modules/fybrik-implicit-copy-batch/values.yaml
+++ b/modules/fybrik-implicit-copy-batch/values.yaml
@@ -38,3 +38,6 @@ copy:
 #    vault: {}
 
   transformations: []
+  readDataType: "LogData"
+  writeDataType: "LogData"
+  writeOperation: "Overwrite"

--- a/modules/fybrik-implicit-copy-stream/templates/streamtransfer.yaml
+++ b/modules/fybrik-implicit-copy-stream/templates/streamtransfer.yaml
@@ -61,6 +61,6 @@ spec:
   imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
   {{ end }}
   noFinalizer: {{ .Values.noFinalizer }}
-  readDataType: "logdata"
-  writeDataType: "logdata"
-  writeOperation: "append"
+  readDataType: {{ .Values.readDataType | quote}}
+  writeDataType: {{ .Values.writeDataType | quote }}
+  writeOperation: {{ .Values.writeOperation | quote }}

--- a/modules/fybrik-implicit-copy-stream/templates/streamtransfer.yaml
+++ b/modules/fybrik-implicit-copy-stream/templates/streamtransfer.yaml
@@ -61,3 +61,6 @@ spec:
   imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
   {{ end }}
   noFinalizer: {{ .Values.noFinalizer }}
+  readDataType: "logdata"
+  writeDataType: "logdata"
+  writeOperation: "append"

--- a/modules/fybrik-implicit-copy-stream/values.yaml
+++ b/modules/fybrik-implicit-copy-stream/values.yaml
@@ -35,3 +35,7 @@ copy:
 #        object_key: ""
 #    format: ""
 #    vault: {}
+
+readDataType: "ChangeData"
+writeDataType: "LogData"
+writeOperation: "Append"


### PR DESCRIPTION
…a (to have the same defaults as the mover)

Signed-off-by: Florian Froese <ffr@zurich.ibm.com>