### PR TITLE
Fybrik application taxonomy - reconciler validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-iinclude Makefile.env
+include Makefile.env
 export DOCKER_TAGNAME ?= latest
 export KUBE_NAMESPACE ?= fybrik-system
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-include Makefile.env
+iinclude Makefile.env
 export DOCKER_TAGNAME ?= latest
 export KUBE_NAMESPACE ?= fybrik-system
 
@@ -21,8 +21,6 @@ deploy: $(TOOLBIN)/kubectl $(TOOLBIN)/helm
 
 .PHONY: test
 test:
-	mkdir /tmp/taxonomy || true
-	cp ../charts/fybrik/files/taxonomy/*.json /tmp/taxonomy/  
 	$(MAKE) -C manager pre-test
 	go test -v ./...
 	# The tests for connectors/egeria are dropped because there are none

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ deploy: $(TOOLBIN)/kubectl $(TOOLBIN)/helm
 
 .PHONY: test
 test:
-	mkdir /tmp/taxonomy || true                                                                                                                           	 cp ../charts/fybrik/files/taxonomy/*.json /tmp/taxonomy/  
+	mkdir /tmp/taxonomy || true
+	cp ../charts/fybrik/files/taxonomy/*.json /tmp/taxonomy/  
 	$(MAKE) -C manager pre-test
 	go test -v ./...
 	# The tests for connectors/egeria are dropped because there are none

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ deploy: $(TOOLBIN)/kubectl $(TOOLBIN)/helm
 
 .PHONY: test
 test:
+	mkdir /tmp/taxonomy || true                                                                                                                           	 cp ../charts/fybrik/files/taxonomy/*.json /tmp/taxonomy/  
 	$(MAKE) -C manager pre-test
 	go test -v ./...
 	# The tests for connectors/egeria are dropped because there are none

--- a/manager/Makefile
+++ b/manager/Makefile
@@ -13,12 +13,11 @@ include $(ROOT_DIR)/hack/make-rules/docker.mk
 include $(ROOT_DIR)/hack/make-rules/verify.mk
 
 pre-test: generate manifests $(TOOLBIN)/etcd $(TOOLBIN)/kube-apiserver
+	mkdir /tmp/taxonomy || true                                                                                                                          
+	cp ../charts/fybrik/files/taxonomy/*.json /tmp/taxonomy/
 
 # Run tests
 test: pre-test
-	mkdir /tmp/taxonomy || true
-	cp ../charts/fybrik/files/taxonomy/*.json /tmp/taxonomy/
-
 	go test ./... -coverprofile cover.out
 
 # Build manager binary

--- a/manager/Makefile
+++ b/manager/Makefile
@@ -16,6 +16,9 @@ pre-test: generate manifests $(TOOLBIN)/etcd $(TOOLBIN)/kube-apiserver
 
 # Run tests
 test: pre-test
+	mkdir /tmp/taxonomy || true
+	cp ../charts/fybrik/files/taxonomy/*.json /tmp/taxonomy/
+
 	go test ./... -coverprofile cover.out
 
 # Build manager binary

--- a/manager/controllers/app/fybrikapplication_controller.go
+++ b/manager/controllers/app/fybrikapplication_controller.go
@@ -77,7 +77,6 @@ func (r *FybrikApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		err := applicationContext.ValidateFybrikApplication("/tmp/taxonomy/application.values.schema.json")
 		// if validation fails
 		if err != nil {
-			// update 2 fields in the status
 			// set error message
 			setErrorCondition(applicationContext, "", "This Fybrik application is invalid")
 			observedStatus.ObservedGeneration = appVersion

--- a/manager/controllers/app/fybrikapplication_controller_unit_test.go
+++ b/manager/controllers/app/fybrikapplication_controller_unit_test.go
@@ -912,7 +912,6 @@ func TestFybrikApplicationWithInvalidInterface(t *testing.T) {
 		Name:      "application-with-errors-2",
 		Namespace: "default",
 	}
-
 	filename := "../../testdata/unittests/fybrikapplication-interfaceErrors.yaml"
 	fybrikApp := &app.FybrikApplication{}
 	g.Expect(readObjectFromFile(filename, fybrikApp)).NotTo(gomega.HaveOccurred())
@@ -921,7 +920,6 @@ func TestFybrikApplicationWithInvalidInterface(t *testing.T) {
 	objs := []runtime.Object{
 		fybrikApp,
 	}
-
 	// Register operator types with the runtime scheme.
 	s := utils.NewScheme(g)
 
@@ -933,7 +931,6 @@ func TestFybrikApplicationWithInvalidInterface(t *testing.T) {
 	req := reconcile.Request{
 		NamespacedName: namespaced,
 	}
-
 	_, err := r.Reconcile(context.Background(), req)
 	g.Expect(err).To(gomega.BeNil())
 

--- a/manager/controllers/app/fybrikapplication_controller_unit_test.go
+++ b/manager/controllers/app/fybrikapplication_controller_unit_test.go
@@ -858,7 +858,7 @@ func TestFybrikApplicationWithNoDatasets(t *testing.T) {
 	g.Expect(newApp.Status.Ready).To(gomega.BeTrue())
 }
 
-//nolint
+//nolint:dupl
 func TestFybrikApplicationWithInvalidAppInfo(t *testing.T) {
 	t.Parallel()
 	g := gomega.NewGomegaWithT(t)
@@ -902,7 +902,7 @@ func TestFybrikApplicationWithInvalidAppInfo(t *testing.T) {
 	g.Expect(newApp.Status.Ready).NotTo(gomega.BeTrue())
 }
 
-//nolint
+//nolint:dupl
 func TestFybrikApplicationWithInvalidInterface(t *testing.T) {
 	t.Parallel()
 	g := gomega.NewGomegaWithT(t)

--- a/manager/controllers/app/fybrikapplication_controller_unit_test.go
+++ b/manager/controllers/app/fybrikapplication_controller_unit_test.go
@@ -857,3 +857,89 @@ func TestFybrikApplicationWithNoDatasets(t *testing.T) {
 	g.Expect(getErrorMessages(newApp)).To(gomega.BeEmpty())
 	g.Expect(newApp.Status.Ready).To(gomega.BeTrue())
 }
+
+func TestFybrikApplicationWithInvalidAppInfo(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewGomegaWithT(t)
+
+	// Set the logger to development mode for verbose logs.
+	logf.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	namespaced := types.NamespacedName{
+		Name:      "application-with-errors",
+		Namespace: "default",
+	}
+
+	filename := "../../testdata/unittests/fybrikapplication-appInfoErrors.yaml"
+	fybrikApp := &app.FybrikApplication{}
+	g.Expect(readObjectFromFile(filename, fybrikApp)).NotTo(gomega.HaveOccurred())
+
+	// Objects to track in the fake client.
+	objs := []runtime.Object{
+		fybrikApp,
+	}
+
+	// Register operator types with the runtime scheme.
+	s := utils.NewScheme(g)
+
+	// Create a fake client to mock API calls.
+	cl := fake.NewFakeClientWithScheme(s, objs...)
+
+	// Create a FybrikApplicationReconciler object with the scheme and fake client.
+	r := createTestFybrikApplicationController(cl, s)
+	req := reconcile.Request{
+		NamespacedName: namespaced,
+	}
+
+	_, err := r.Reconcile(context.Background(), req)
+	g.Expect(err).To(gomega.BeNil())
+
+	newApp := &app.FybrikApplication{}
+	err = cl.Get(context.Background(), req.NamespacedName, newApp)
+	g.Expect(err).To(gomega.BeNil(), "Cannot fetch fybrikapplication")
+	g.Expect(getErrorMessages(newApp)).NotTo(gomega.BeEmpty())
+	g.Expect(newApp.Status.Ready).NotTo(gomega.BeTrue())
+}
+
+func TestFybrikApplicationWithInvalidInterface(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewGomegaWithT(t)
+
+	// Set the logger to development mode for verbose logs.
+	logf.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	namespaced := types.NamespacedName{
+		Name:      "application-with-errors-2",
+		Namespace: "default",
+	}
+
+	filename := "../../testdata/unittests/fybrikapplication-interfaceErrors.yaml"
+	fybrikApp := &app.FybrikApplication{}
+	g.Expect(readObjectFromFile(filename, fybrikApp)).NotTo(gomega.HaveOccurred())
+
+	// Objects to track in the fake client.
+	objs := []runtime.Object{
+		fybrikApp,
+	}
+
+	// Register operator types with the runtime scheme.
+	s := utils.NewScheme(g)
+
+	// Create a fake client to mock API calls.
+	cl := fake.NewFakeClientWithScheme(s, objs...)
+
+	// Create a FybrikApplicationReconciler object with the scheme and fake client.
+	r := createTestFybrikApplicationController(cl, s)
+	req := reconcile.Request{
+		NamespacedName: namespaced,
+	}
+
+	_, err := r.Reconcile(context.Background(), req)
+	g.Expect(err).To(gomega.BeNil())
+
+	newApp := &app.FybrikApplication{}
+	err = cl.Get(context.Background(), req.NamespacedName, newApp)
+	g.Expect(err).To(gomega.BeNil(), "Cannot fetch fybrikapplication")
+	g.Expect(getErrorMessages(newApp)).NotTo(gomega.BeEmpty())
+	g.Expect(newApp.Status.Ready).NotTo(gomega.BeTrue())
+}

--- a/manager/controllers/app/fybrikapplication_controller_unit_test.go
+++ b/manager/controllers/app/fybrikapplication_controller_unit_test.go
@@ -858,6 +858,7 @@ func TestFybrikApplicationWithNoDatasets(t *testing.T) {
 	g.Expect(newApp.Status.Ready).To(gomega.BeTrue())
 }
 
+//nolint
 func TestFybrikApplicationWithInvalidAppInfo(t *testing.T) {
 	t.Parallel()
 	g := gomega.NewGomegaWithT(t)
@@ -901,6 +902,7 @@ func TestFybrikApplicationWithInvalidAppInfo(t *testing.T) {
 	g.Expect(newApp.Status.Ready).NotTo(gomega.BeTrue())
 }
 
+//nolint
 func TestFybrikApplicationWithInvalidInterface(t *testing.T) {
 	t.Parallel()
 	g := gomega.NewGomegaWithT(t)

--- a/manager/testdata/unittests/data-usage.yaml
+++ b/manager/testdata/unittests/data-usage.yaml
@@ -9,7 +9,8 @@ spec:
    workloadSelector:
      matchLabels: {run: notebook}
   appInfo:
-    intent: Testing
+    intent: Fraud Detection
+    role: Security
   data:
     - dataSetID: s3/redact-dataset
       requirements:

--- a/manager/testdata/unittests/fybrikapplication-appInfoErrors.yaml
+++ b/manager/testdata/unittests/fybrikapplication-appInfoErrors.yaml
@@ -2,6 +2,7 @@ apiVersion: app.fybrik.io/v1alpha1
 kind: FybrikApplication
 metadata:
   name: application-with-errors
+  namespace: default
   labels:
     app: kf-notebook
 spec:
@@ -13,7 +14,7 @@ spec:
   appInfo:
     role: Hacker
   data:
-    - dataSetID: "{\"ServerName\":\"mds1\",\"AssetGuid\":\"ASSET_ID\"}"
+    - dataSetID: s3/redact-dataset
       requirements:
         interface: 
           protocol: fybrik-arrow-flight

--- a/manager/testdata/unittests/fybrikapplication-interfaceErrors.yaml
+++ b/manager/testdata/unittests/fybrikapplication-interfaceErrors.yaml
@@ -2,6 +2,7 @@ apiVersion: app.fybrik.io/v1alpha1
 kind: FybrikApplication
 metadata:
   name: application-with-errors-2
+  namespace: default
   labels:
     app: kf-notebook
 spec:
@@ -14,7 +15,7 @@ spec:
     intent: Fraud Detection
     role: Sales
   data:
-    - dataSetID: "{\"ServerName\":\"mds1\",\"AssetGuid\":\"ASSET_ID\"}"
+    - dataSetID: s3/redact-dataset
       requirements:
         interface: 
           protocol: kafka

--- a/manager/testdata/unittests/fybrikcopyapp-csv.yaml
+++ b/manager/testdata/unittests/fybrikcopyapp-csv.yaml
@@ -15,7 +15,8 @@ spec:
       matchLabels:
         app: notebook
   appInfo:
-    intent: fraud-detection
+    intent: Fraud Detection
+    role: Security
   data:
   - dataSetID: "s3-csv/redact-dataset"
     requirements:


### PR DESCRIPTION
This PR makes the following changes:

- adds Fybrik application taxonomy validation code to the Reconciler
- adds controller unit tests to check if this validation is working with invalid Fybrik applications
- modifies the Makefile in `manager` to copy `charts/fybrik/files/taxonomy` to `/tmp/taxonomy` to make the unit tests work
- modifies the Fybrik applications in `manager/testdata/unittests` to be compliant with Fybrik application taxonomy
