### PR TITLE
Release: improve image tags for public images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,9 @@ name: Build
 
 on:
   push:
-    branches:
-      - master
+    branches-ignore:
+      - 'releases/**'
+      - 'site'
     tags:
       - '*'
   pull_request:
@@ -127,13 +128,22 @@ jobs:
       name: Infer version
       run: |
         version="${GITHUB_REF#refs/tags/v}"
+        push_tag_event='true'
         if  [[ $version == refs/* ]] ;
         then
-            version="latest"
+            push_tag_event='false'
+            branch="${GITHUB_REF#refs/heads/}"
+            version=$branch
         fi
         echo ::set-output name=version::$version
+        echo ::set-output name=push_tag_event::$push_tag_event
     - name: Publish images
       if: ${{ github.event_name != 'pull_request' }}
       env:
         DOCKER_PUBLIC_TAGNAME:  ${{ steps.version.outputs.version }}
+      run: make docker-retag-and-push-public && make helm-push-public
+    - name: Publish latest image tag on push tag event
+      if: github.event_name != 'pull_request' && steps.version.outputs.push_tag_event == 'true'
+      env:
+        DOCKER_PUBLIC_TAGNAME: 'latest'
       run: make docker-retag-and-push-public && make helm-push-public

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 include Makefile.env
-export DOCKER_TAGNAME ?= latest
+export DOCKER_TAGNAME ?= master
 export KUBE_NAMESPACE ?= fybrik-system
 
 .PHONY: license
@@ -87,7 +87,7 @@ docker-push:
 
 DOCKER_PUBLIC_HOSTNAME ?= ghcr.io
 DOCKER_PUBLIC_NAMESPACE ?= fybrik
-DOCKER_PUBLIC_TAGNAME ?= latest
+DOCKER_PUBLIC_TAGNAME ?= master
 
 DOCKER_PUBLIC_NAMES := \
 	manager \

--- a/charts/fybrik-crd/Chart.yaml
+++ b/charts/fybrik-crd/Chart.yaml
@@ -11,4 +11,4 @@ type: application
 version: 0.0.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. 
-appVersion: latest
+appVersion: master

--- a/charts/fybrik/Chart.yaml
+++ b/charts/fybrik/Chart.yaml
@@ -11,4 +11,4 @@ type: application
 version: 0.0.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: latest
+appVersion: master

--- a/charts/fybrik/integration-tests.values.yaml
+++ b/charts/fybrik/integration-tests.values.yaml
@@ -5,7 +5,7 @@
 # Global configuration applies to multiple components installed by this chart
 global:
   hub: localhost:5000/fybrik-system
-  tag: "latest"
+  tag: "master"
   imagePullPolicy: "Always"
 
 # Manager component

--- a/charts/fybrik/kind-control.values.yaml
+++ b/charts/fybrik/kind-control.values.yaml
@@ -5,7 +5,7 @@
 # Global configuration applies to multiple components installed by this chart
 global:
   hub: localhost:5000/fybrik-system
-  tag: "latest"
+  tag: "master"
   imagePullPolicy: "Always"
 
 # Cluster metadata values

--- a/charts/fybrik/kind-kind.values.yaml
+++ b/charts/fybrik/kind-kind.values.yaml
@@ -5,7 +5,7 @@
 # Global configuration applies to multiple components installed by this chart
 global:
   hub: localhost:5000/fybrik-system
-  tag: "latest"
+  tag: "master"
   imagePullPolicy: "Always"
 
 # Cluster metadata values

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -2,7 +2,7 @@
 # Copyright 2020 IBM Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-: ${RELEASE:=latest}
+: ${RELEASE:=master}
 : ${TOOLBIN:=./hack/tools/bin}
 
 ${TOOLBIN}/yq eval --inplace ".version = \"$RELEASE\"" ./charts/fybrik/Chart.yaml

--- a/manager/testdata/batchtransfer.yaml
+++ b/manager/testdata/batchtransfer.yaml
@@ -37,7 +37,7 @@ spec:
     columns: ["BLOOD_GROUP"]
     options:
       algo: md5
-  image: localhost:5000/fybrik-system/dummy-mover:latest
+  image: localhost:5000/fybrik-system/dummy-mover:master
   imagePullPolicy: "IfNotPresent"
   maxFailedRetries: 0
   successfulJobHistoryLimit: 3

--- a/manager/testdata/streamtransfer.yaml
+++ b/manager/testdata/streamtransfer.yaml
@@ -37,7 +37,7 @@ spec:
     columns: ["BLOOD_GROUP"]
     options:
       algo: md5
-  image: localhost:5000/fybrik-system/dummy-mover:latest
+  image: localhost:5000/fybrik-system/dummy-mover:master
   imagePullPolicy: "IfNotPresent"
   maxFailedRetries: 0
   successfulJobHistoryLimit: 3

--- a/site/docs/get-started/quickstart.md
+++ b/site/docs/get-started/quickstart.md
@@ -105,7 +105,7 @@ Run the following to install vault and the plugin in development mode:
     git clone https://github.com/fybrik/fybrik.git
     cd fybrik
     helm install fybrik-crd charts/fybrik-crd -n fybrik-system --wait
-    helm install fybrik charts/fybrik --set global.tag=latest -n fybrik-system --wait
+    helm install fybrik charts/fybrik --set global.tag=master -n fybrik-system --wait
     ```
 
 The control plane includes a `manager` service that connects to a data catalog and to a policy manager. 


### PR DESCRIPTION
As explained in issue  #499 this PR changes public images tags as follows:

The current behavior is:

    Releases are pushed as release version (X.Y.Z)
    master is pushed as latest

The new behavior is:

    Releases are pushed as release version (X.Y.Z) and latest
    Branches are pushed using branch name (i.e. master)

Also, in this PR CI tests are triggered for branches except for releases and site branches.
If we would choose to change the way we do releases as @roee88 suggested we would consider
triggering CI tests also for releases branches.

Closes #499 