### PR TITLE
Adding step in github action to use go 1.16

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -9,6 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16      
       - name: Run license check
         run: |
           go get -u github.com/google/addlicense


### PR DESCRIPTION
This PR adds a step in github action to use go 1.16 for license check workflow. 
Signed-off-by: Rohith D Vallam <rovallam@in.ibm.com>