### PR TITLE
Reduce reconcile time in blueprint deletion

### DIFF
--- a/manager/controllers/app/blueprint_controller.go
+++ b/manager/controllers/app/blueprint_controller.go
@@ -93,10 +93,6 @@ func (r *BlueprintReconciler) reconcileFinalizers(blueprint *app.Blueprint) (ctr
 			// the finalizer is present - delete the allocated resources
 			if err := r.deleteExternalResources(blueprint); err != nil {
 				r.Log.V(0).Info("Error while deleting owned resources: " + err.Error())
-				return ctrl.Result{}, err
-			}
-			if r.hasExternalResources(blueprint) {
-				return ctrl.Result{RequeueAfter: 2 * time.Second}, errors.NewPlain("helm release uninstall is still in progress")
 			}
 			// remove the finalizer from the list and update it, because it needs to be deleted together with the object
 			ctrlutil.RemoveFinalizer(blueprint, finalizerName)
@@ -119,12 +115,8 @@ func (r *BlueprintReconciler) reconcileFinalizers(blueprint *app.Blueprint) (ctr
 
 func (r *BlueprintReconciler) deleteExternalResources(blueprint *app.Blueprint) error {
 	errs := make([]string, 0)
-	for _, module := range blueprint.Spec.Modules {
-		releaseName := utils.GetReleaseName(blueprint.Labels[app.ApplicationNameLabel], blueprint.Labels[app.ApplicationNamespaceLabel], module)
-		if rel, errStatus := r.Helmer.Status(blueprint.Namespace, releaseName); errStatus != nil || rel == nil {
-			continue
-		}
-		if _, err := r.Helmer.Uninstall(blueprint.Namespace, releaseName); err != nil {
+	for release := range blueprint.Status.Releases {
+		if _, err := r.Helmer.Uninstall(blueprint.Namespace, release); err != nil {
 			errs = append(errs, err.Error())
 		}
 	}
@@ -132,16 +124,6 @@ func (r *BlueprintReconciler) deleteExternalResources(blueprint *app.Blueprint) 
 		return nil
 	}
 	return errors.New(strings.Join(errs, "; "))
-}
-
-func (r *BlueprintReconciler) hasExternalResources(blueprint *app.Blueprint) bool {
-	for _, module := range blueprint.Spec.Modules {
-		releaseName := utils.GetReleaseName(blueprint.Labels[app.ApplicationNameLabel], blueprint.Labels[app.ApplicationNamespaceLabel], module)
-		if rel, errStatus := r.Helmer.Status(blueprint.Namespace, releaseName); errStatus == nil && rel != nil {
-			return true
-		}
-	}
-	return false
 }
 
 func (r *BlueprintReconciler) applyChartResource(log logr.Logger, chartSpec app.ChartSpec, args map[string]interface{}, blueprint *app.Blueprint, releaseName string) (ctrl.Result, error) {


### PR DESCRIPTION
Signed-off-by: Shlomit Koyfman <shlomitk@il.ibm.com>

Partially fixes https://github.com/fybrik/fybrik/issues/710

This PR reduces time required for a blueprint reconcile:
- No redundant calls for helm status are made. 
- After uninstall no checking is done to check whether uninstall is in progress.