### PR TITLE
Make the concurrent reconciles and client qps and burst configurable …

### DIFF
--- a/charts/fybrik/integration-tests.values.yaml
+++ b/charts/fybrik/integration-tests.values.yaml
@@ -13,6 +13,21 @@ manager:
   # Set to true to enable socat in the manager pod to forward
   # traffic from a localhost registry. Used only for development and integration tests.
   socat: true
+  extraEnvs:
+  - name: APPLICATION_CONCURRENT_RECONCILES
+    value: "5"
+  - name: BLUEPRINT_CONCURRENT_RECONCILES
+    value: "20"
+  - name: PLOTTER_CONCURRENT_RECONCILES
+    value: "2"
+  - name: BATCHTRANSFER_CONCURRENT_RECONCILES
+    value: "1"
+  - name: STREAMTRANSFER_CONCURRENT_RECONCILES
+    value: "1"
+  - name: CLIENT_QPS
+    value: "100.0"
+  - name: CLIENT_BURST
+    value: "200"
 
 # OPA connector component
 opaConnector:

--- a/manager/apis/motion/v1alpha1/batchtransfer_webhook.go
+++ b/manager/apis/motion/v1alpha1/batchtransfer_webhook.go
@@ -5,7 +5,7 @@ package v1alpha1
 
 import (
 	"fmt"
-	log "log"
+	"log"
 	"net"
 	"net/url"
 	"os"

--- a/manager/apis/motion/v1alpha1/streamtransfer_webhook.go
+++ b/manager/apis/motion/v1alpha1/streamtransfer_webhook.go
@@ -4,14 +4,13 @@
 package v1alpha1
 
 import (
-	"log"
-	"os"
-
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"log"
+	"os"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )

--- a/manager/apis/motion/v1alpha1/streamtransfer_webhook.go
+++ b/manager/apis/motion/v1alpha1/streamtransfer_webhook.go
@@ -4,13 +4,14 @@
 package v1alpha1
 
 import (
+	"log"
+	"os"
+
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"log"
-	"os"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )

--- a/manager/controllers/app/blueprint_controller.go
+++ b/manager/controllers/app/blueprint_controller.go
@@ -6,8 +6,9 @@ package app
 import (
 	"context"
 	"fmt"
+	"fybrik.io/fybrik/manager/controllers"
+	"fybrik.io/fybrik/pkg/environment"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"strconv"
 	"strings"
 	"time"
 
@@ -321,9 +322,9 @@ func (r *BlueprintReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		},
 	}
 
-	numReconciles := utils.GetEnvAsInt("BLUEPRINT_CONCURRENT_RECONCILES", 5)
+	numReconciles := environment.GetEnvAsInt(controllers.BlueprintConcurrentReconcilesConfiguration, controllers.DefaultBlueprintConcurrentReconciles)
 
-	mgr.GetLogger().Info("Concurrent blueprint reconciles " + strconv.Itoa(numReconciles))
+	mgr.GetLogger().Info(fmt.Sprintf("Concurrent blueprint reconciles: %d", numReconciles))
 
 	return ctrl.NewControllerManagedBy(mgr).
 		WithOptions(controller.Options{MaxConcurrentReconciles: numReconciles}).

--- a/manager/controllers/app/blueprint_controller.go
+++ b/manager/controllers/app/blueprint_controller.go
@@ -6,6 +6,8 @@ package app
 import (
 	"context"
 	"fmt"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"strconv"
 	"strings"
 	"time"
 
@@ -319,7 +321,12 @@ func (r *BlueprintReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		},
 	}
 
+	numReconciles := utils.GetEnvAsInt("BLUEPRINT_CONCURRENT_RECONCILES", 5)
+
+	mgr.GetLogger().Info("Concurrent blueprint reconciles " + strconv.Itoa(numReconciles))
+
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.Options{MaxConcurrentReconciles: numReconciles}).
 		For(&app.Blueprint{}).
 		WithEventFilter(p).
 		Complete(r)

--- a/manager/controllers/app/fybrikapplication_controller.go
+++ b/manager/controllers/app/fybrikapplication_controller.go
@@ -6,6 +6,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"strings"
 	"time"
 
@@ -490,7 +491,11 @@ func (r *FybrikApplicationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			}},
 		}
 	}
+
+	numReconciles := utils.GetEnvAsInt("APPLICATION_CONCURRENT_RECONCILES", 5)
+
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.Options{MaxConcurrentReconciles: numReconciles}).
 		For(&api.FybrikApplication{}).
 		Watches(&source.Kind{
 			Type: &api.Plotter{},

--- a/manager/controllers/app/fybrikapplication_controller.go
+++ b/manager/controllers/app/fybrikapplication_controller.go
@@ -6,6 +6,8 @@ package app
 import (
 	"context"
 	"fmt"
+	"fybrik.io/fybrik/manager/controllers"
+	"fybrik.io/fybrik/pkg/environment"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"strings"
 	"time"
@@ -492,7 +494,7 @@ func (r *FybrikApplicationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		}
 	}
 
-	numReconciles := utils.GetEnvAsInt("APPLICATION_CONCURRENT_RECONCILES", 5)
+	numReconciles := environment.GetEnvAsInt(controllers.ApplicationConcurrentReconcilesConfiguration, controllers.DefaultApplicationConcurrentReconciles)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		WithOptions(controller.Options{MaxConcurrentReconciles: numReconciles}).

--- a/manager/controllers/app/plotter_controller.go
+++ b/manager/controllers/app/plotter_controller.go
@@ -5,7 +5,8 @@ package app
 
 import (
 	"context"
-	"fybrik.io/fybrik/manager/controllers/utils"
+	"fybrik.io/fybrik/manager/controllers"
+	"fybrik.io/fybrik/pkg/environment"
 	"math"
 	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -304,7 +305,7 @@ func NewPlotterReconciler(mgr ctrl.Manager, name string, manager multicluster.Cl
 
 // SetupWithManager registers Plotter controller
 func (r *PlotterReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	numReconciles := utils.GetEnvAsInt("PLOTTER_CONCURRENT_RECONCILES", 5)
+	numReconciles := environment.GetEnvAsInt(controllers.PlotterConcurrentReconcilesConfiguration, controllers.DefaultPlotterConcurrentReconciles)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		WithOptions(controller.Options{MaxConcurrentReconciles: numReconciles}).

--- a/manager/controllers/app/plotter_controller.go
+++ b/manager/controllers/app/plotter_controller.go
@@ -5,8 +5,10 @@ package app
 
 import (
 	"context"
+	"fybrik.io/fybrik/manager/controllers/utils"
 	"math"
 	"reflect"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"strings"
 	"time"
 
@@ -302,7 +304,10 @@ func NewPlotterReconciler(mgr ctrl.Manager, name string, manager multicluster.Cl
 
 // SetupWithManager registers Plotter controller
 func (r *PlotterReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	numReconciles := utils.GetEnvAsInt("PLOTTER_CONCURRENT_RECONCILES", 5)
+
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.Options{MaxConcurrentReconciles: numReconciles}).
 		For(&app.Plotter{}).
 		Complete(r)
 }

--- a/manager/controllers/constants.go
+++ b/manager/controllers/constants.go
@@ -1,3 +1,6 @@
+// Copyright 2021 IBM Corp.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllers
 
 // This is a collection of constants related to the manager and it's configuration

--- a/manager/controllers/constants.go
+++ b/manager/controllers/constants.go
@@ -1,0 +1,23 @@
+package controllers
+
+// This is a collection of constants related to the manager and it's configuration
+
+const ApplicationConcurrentReconcilesConfiguration = "APPLICATION_CONCURRENT_RECONCILES"
+const PlotterConcurrentReconcilesConfiguration = "PLOTTER_CONCURRENT_RECONCILES"
+const BlueprintConcurrentReconcilesConfiguration = "BLUEPRINT_CONCURRENT_RECONCILES"
+
+const BatchTransferConcurrentReconcilesConfiguration = "BATCHTRANSFER_CONCURRENT_RECONCILES"
+const StreamTransferConcurrentReconcilesConfiguration = "STREAMTRANSFER_CONCURRENT_RECONCILES"
+
+const KubernetesClientQPSConfiguration = "CLIENT_QPS"
+const KubernetesClientBurstConfiguration = "CLIENT_BURST"
+
+const DefaultApplicationConcurrentReconciles = 1
+const DefaultPlotterConcurrentReconciles = 1
+const DefaultBlueprintConcurrentReconciles = 1
+
+const DefaultBatchTransferConcurrentReconciles = 1
+const DefaultStreamTransferConcurrentReconciles = 1
+
+const DefaultKubernetesClientQPS = 5.0  // Default from Kubernetes client: 5
+const DefaultKubernetesClientBurst = 10 // Default from Kubernetes client: 10

--- a/manager/controllers/motion/batchtransfer_controller.go
+++ b/manager/controllers/motion/batchtransfer_controller.go
@@ -6,8 +6,8 @@ package motion
 import (
 	"context"
 	"fmt"
-
 	motionv1 "fybrik.io/fybrik/manager/apis/motion/v1alpha1"
+	"fybrik.io/fybrik/manager/controllers/utils"
 	"github.com/go-logr/logr"
 	kbatch "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -16,6 +16,7 @@ import (
 	"k8s.io/client-go/tools/reference"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 )
 
 // A reconciler can be used to base reconcilers of Transfers on.
@@ -164,7 +165,10 @@ func (reconciler *BatchTransferReconciler) Reconcile(ctx context.Context, req ct
 
 // Setup the reconciler. This consists of creating an index of jobs where this controller is the owner.
 func (reconciler *BatchTransferReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	numReconciles := utils.GetEnvAsInt("BATCHTRANSFER_CONCURRENT_RECONCILES", 1)
+
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.Options{MaxConcurrentReconciles: numReconciles}).
 		For(&motionv1.BatchTransfer{}).
 		Owns(&kbatch.Job{}).
 		Owns(&corev1.Pod{}).

--- a/manager/controllers/motion/batchtransfer_controller.go
+++ b/manager/controllers/motion/batchtransfer_controller.go
@@ -7,7 +7,8 @@ import (
 	"context"
 	"fmt"
 	motionv1 "fybrik.io/fybrik/manager/apis/motion/v1alpha1"
-	"fybrik.io/fybrik/manager/controllers/utils"
+	"fybrik.io/fybrik/manager/controllers"
+	"fybrik.io/fybrik/pkg/environment"
 	"github.com/go-logr/logr"
 	kbatch "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -165,7 +166,7 @@ func (reconciler *BatchTransferReconciler) Reconcile(ctx context.Context, req ct
 
 // Setup the reconciler. This consists of creating an index of jobs where this controller is the owner.
 func (reconciler *BatchTransferReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	numReconciles := utils.GetEnvAsInt("BATCHTRANSFER_CONCURRENT_RECONCILES", 1)
+	numReconciles := environment.GetEnvAsInt(controllers.BatchTransferConcurrentReconcilesConfiguration, controllers.DefaultBatchTransferConcurrentReconciles)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		WithOptions(controller.Options{MaxConcurrentReconciles: numReconciles}).

--- a/manager/controllers/motion/streamtransfer_controller.go
+++ b/manager/controllers/motion/streamtransfer_controller.go
@@ -6,7 +6,8 @@ package motion
 import (
 	"context"
 	"fmt"
-	"fybrik.io/fybrik/manager/controllers/utils"
+	"fybrik.io/fybrik/manager/controllers"
+	"fybrik.io/fybrik/pkg/environment"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -131,7 +132,7 @@ func (reconciler *StreamTransferReconciler) Reconcile(ctx context.Context, req c
 }
 
 func (reconciler *StreamTransferReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	numReconciles := utils.GetEnvAsInt("STREAMTRANSFER_CONCURRENT_RECONCILES", 1)
+	numReconciles := environment.GetEnvAsInt(controllers.StreamTransferConcurrentReconcilesConfiguration, controllers.DefaultStreamTransferConcurrentReconciles)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		WithOptions(controller.Options{MaxConcurrentReconciles: numReconciles}).

--- a/manager/controllers/motion/streamtransfer_controller.go
+++ b/manager/controllers/motion/streamtransfer_controller.go
@@ -6,12 +6,13 @@ package motion
 import (
 	"context"
 	"fmt"
-
+	"fybrik.io/fybrik/manager/controllers/utils"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	motionv1 "fybrik.io/fybrik/manager/apis/motion/v1alpha1"
 )
@@ -130,7 +131,10 @@ func (reconciler *StreamTransferReconciler) Reconcile(ctx context.Context, req c
 }
 
 func (reconciler *StreamTransferReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	numReconciles := utils.GetEnvAsInt("STREAMTRANSFER_CONCURRENT_RECONCILES", 1)
+
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.Options{MaxConcurrentReconciles: numReconciles}).
 		For(&motionv1.StreamTransfer{}).
 		Owns(&apps.Deployment{}).
 		Complete(reconciler)

--- a/manager/controllers/utils/utils.go
+++ b/manager/controllers/utils/utils.go
@@ -9,13 +9,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
-	"runtime"
-	"sort"
-	"strconv"
-
 	app "fybrik.io/fybrik/manager/apis/app/v1alpha1"
 	dc "fybrik.io/fybrik/pkg/connectors/protobuf"
+	"runtime"
+	"sort"
 )
 
 // GetProtocol returns the existing data protocol
@@ -171,28 +168,4 @@ func GetModuleCapabilities(module *app.FybrikModule, requestedCapability app.Cap
 		}
 	}
 	return capFound, capList
-}
-
-// Returns the integer value of an environment variable.
-// If the environment variable is not set or cannot be parsed the default value is returned.
-func GetEnvAsInt(key string, defaultValue int) int {
-	if env, isSet := os.LookupEnv(key); isSet {
-		i, err := strconv.Atoi(env)
-		if err == nil {
-			return i
-		}
-	}
-	return defaultValue
-}
-
-// Returns the float32 value of an environment variable.
-// If the environment variable is not set or cannot be parsed the default value is returned.
-func GetEnvAsFloat32(key string, defaultValue float32) float32 {
-	if env, isSet := os.LookupEnv(key); isSet {
-		f, err := strconv.ParseFloat(env, 32)
-		if err == nil {
-			return float32(f)
-		}
-	}
-	return defaultValue
 }

--- a/manager/controllers/utils/utils.go
+++ b/manager/controllers/utils/utils.go
@@ -9,8 +9,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"runtime"
 	"sort"
+	"strconv"
 
 	app "fybrik.io/fybrik/manager/apis/app/v1alpha1"
 	dc "fybrik.io/fybrik/pkg/connectors/protobuf"
@@ -169,4 +171,28 @@ func GetModuleCapabilities(module *app.FybrikModule, requestedCapability app.Cap
 		}
 	}
 	return capFound, capList
+}
+
+// Returns the integer value of an environment variable.
+// If the environment variable is not set or cannot be parsed the default value is returned.
+func GetEnvAsInt(key string, defaultValue int) int {
+	if env, isSet := os.LookupEnv(key); isSet {
+		i, err := strconv.Atoi(env)
+		if err == nil {
+			return i
+		}
+	}
+	return defaultValue
+}
+
+// Returns the float32 value of an environment variable.
+// If the environment variable is not set or cannot be parsed the default value is returned.
+func GetEnvAsFloat32(key string, defaultValue float32) float32 {
+	if env, isSet := os.LookupEnv(key); isSet {
+		f, err := strconv.ParseFloat(env, 32)
+		if err == nil {
+			return float32(f)
+		}
+	}
+	return defaultValue
 }

--- a/manager/main.go
+++ b/manager/main.go
@@ -72,7 +72,13 @@ func run(namespace string, metricsAddr string, enableLeaderElection bool,
 		&corev1.PersistentVolumeClaim{}: {Field: workerNamespaceSelector},
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	client := ctrl.GetConfigOrDie()
+	client.QPS = utils.GetEnvAsFloat32("CLIENT_QPS", 100.0)
+	client.Burst = utils.GetEnvAsInt("CLIENT_BURST", 200)
+
+	setupLog.Info("Manager client rate limits:", "qps", client.QPS, "burst", client.Burst)
+
+	mgr, err := ctrl.NewManager(client, ctrl.Options{
 		Scheme:             scheme,
 		Namespace:          namespace,
 		MetricsBindAddress: metricsAddr,

--- a/manager/main.go
+++ b/manager/main.go
@@ -5,6 +5,8 @@ package main
 
 import (
 	"flag"
+	"fybrik.io/fybrik/manager/controllers"
+	"fybrik.io/fybrik/pkg/environment"
 	"os"
 	"strconv"
 	"strings"
@@ -73,8 +75,8 @@ func run(namespace string, metricsAddr string, enableLeaderElection bool,
 	}
 
 	client := ctrl.GetConfigOrDie()
-	client.QPS = utils.GetEnvAsFloat32("CLIENT_QPS", 100.0)
-	client.Burst = utils.GetEnvAsInt("CLIENT_BURST", 200)
+	client.QPS = environment.GetEnvAsFloat32(controllers.KubernetesClientQPSConfiguration, controllers.DefaultKubernetesClientQPS)
+	client.Burst = environment.GetEnvAsInt(controllers.KubernetesClientBurstConfiguration, controllers.DefaultKubernetesClientBurst)
 
 	setupLog.Info("Manager client rate limits:", "qps", client.QPS, "burst", client.Burst)
 

--- a/pkg/environment/utils.go
+++ b/pkg/environment/utils.go
@@ -1,0 +1,30 @@
+package environment
+
+import (
+	"os"
+	"strconv"
+)
+
+// Returns the integer value of an environment variable.
+// If the environment variable is not set or cannot be parsed the default value is returned.
+func GetEnvAsInt(key string, defaultValue int) int {
+	if env, isSet := os.LookupEnv(key); isSet {
+		i, err := strconv.Atoi(env)
+		if err == nil {
+			return i
+		}
+	}
+	return defaultValue
+}
+
+// Returns the float32 value of an environment variable.
+// If the environment variable is not set or cannot be parsed the default value is returned.
+func GetEnvAsFloat32(key string, defaultValue float32) float32 {
+	if env, isSet := os.LookupEnv(key); isSet {
+		f, err := strconv.ParseFloat(env, 32)
+		if err == nil {
+			return float32(f)
+		}
+	}
+	return defaultValue
+}

--- a/pkg/environment/utils.go
+++ b/pkg/environment/utils.go
@@ -1,3 +1,6 @@
+// Copyright 2021 IBM Corp.
+// SPDX-License-Identifier: Apache-2.0
+
 package environment
 
 import (


### PR DESCRIPTION
…for the manager

Fixes #684 

This PR allows to increase the limits of parallel reconciliation of objects as well as the client rates. 
The default client QPS is 5 and Burst is 10 which is fairly low when executing batch operations on thousands of objects.