### PR TITLE
Support both openapi and grpc manager creation based on manager url

### DIFF
--- a/manager/main.go
+++ b/manager/main.go
@@ -247,19 +247,13 @@ func newPolicyManager() (connectors.PolicyManager, error) {
 	setupLog.Info("setting main policy manager client", "Name", mainPolicyManagerName, "URL", mainPolicyManagerURL, "Timeout", connectionTimeout)
 
 	var policyManager connectors.PolicyManager
-	if strings.Contains(mainPolicyManagerURL, "http") {
+	if strings.HasPrefix(mainPolicyManagerURL, "http") {
 		policyManager, err = connectors.NewOpenAPIPolicyManager(mainPolicyManagerName, mainPolicyManagerURL, connectionTimeout)
-		if err != nil {
-			return nil, err
-		}
 	} else {
 		policyManager, err = connectors.NewGrpcPolicyManager(mainPolicyManagerName, mainPolicyManagerURL, connectionTimeout)
-		if err != nil {
-			return nil, err
-		}
 	}
 
-	return policyManager, nil
+	return policyManager, err
 }
 
 // newClusterManager decides based on the environment variables that are set which

--- a/manager/main.go
+++ b/manager/main.go
@@ -246,9 +246,17 @@ func newPolicyManager() (connectors.PolicyManager, error) {
 	mainPolicyManagerURL := os.Getenv("MAIN_POLICY_MANAGER_CONNECTOR_URL")
 	setupLog.Info("setting main policy manager client", "Name", mainPolicyManagerName, "URL", mainPolicyManagerURL, "Timeout", connectionTimeout)
 
-	policyManager, err := connectors.NewOpenAPIPolicyManager(mainPolicyManagerName, mainPolicyManagerURL, connectionTimeout)
-	if err != nil {
-		return nil, err
+	var policyManager connectors.PolicyManager
+	if strings.Contains(mainPolicyManagerURL, "http") {
+		policyManager, err = connectors.NewOpenAPIPolicyManager(mainPolicyManagerName, mainPolicyManagerURL, connectionTimeout)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		policyManager, err = connectors.NewGrpcPolicyManager(mainPolicyManagerName, mainPolicyManagerURL, connectionTimeout)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return policyManager, nil


### PR DESCRIPTION
This PR fixes issue raised by Latha which was giving the below error .
```

2021-08-25T06:00:18.743Z	INFO	controllers.FybrikApplication	Listing all modules
2021-08-25T06:00:18.743Z	INFO	controllers.FybrikApplication	arrow-flight-module
2021-08-25T06:00:18.743Z	INFO	controllers.FybrikApplication	Select modules for {"asset_id": "b00afa87-fc56-4a60-9bd6-ab11a9f1c266", "catalog_id": "afbdd6c9-8cb3-4634-9e8e-42fca731505b"}
2021-08-25T06:00:18.743Z	INFO	controllers.FybrikApplication	Select read path for {"asset_id": "b00afa87-fc56-4a60-9bd6-ab11a9f1c266", "catalog_id": "afbdd6c9-8cb3-4634-9e8e-42fca731505b"}
2021/08/25 06:00:18 transformed openapi request:  &{0xc00063c3b8 {0xc000e9c7e0 0xc000e9c7f0 0xc000e9c7d0} {{"asset_id": "b00afa87-fc56-4a60-9bd6-ab11a9f1c266", "catalog_id": "afbdd6c9-8cb3-4634-9e8e-42fca731505b"} <nil> <nil>}}
Error when calling `DefaultApi.GetPoliciesDecisions``: Post "wkc-connector:50090/getPoliciesDecisions": unsupported protocol scheme "wkc-connector"
Full HTTP response: <nil>
2021/08/25 06:00:18 openapi response received:  <nil>
2021/08/25 06:00:18 err : <nil>
2021/08/25 06:00:18 Marshalled response in ConvertOpenAPIRespToGrpcResp: null
2021/08/25 06:00:18 returning policiesDecision in ConvertOpenAPIRespToGrpcResp:  dataset_decisions:{dataset:{dataset_id:"{\"asset_id\": \"b00afa87-fc56-4a60-9bd6-ab11a9f1c266\", \"catalog_id\": \"afbdd6c9-8cb3-4634-9e8e-42fca731505b\"}"} decisions:{operation:{type:READ destination:"Netherlands"}}}
2021/08/25 06:00:18 transformed grpc response:  dataset_decisions:{dataset:{dataset_id:"{\"asset_id\": \"b00afa87-fc56-4a60-9bd6-ab11a9f1c266\", \"catalog_id\": \"afbdd6c9-8cb3-4634-9e8e-42fca731505b\"}"} decisions:{operation:{type:READ destination:"Netherlands"}}}
2021-08-25T06:00:18.743Z	INFO	controllers.FybrikApplication	Could not select a read module for {"asset_id": "b00afa87-fc56-4a60-9bd6-ab11a9f1c266", "catalog_id": "afbdd6c9-8cb3-4634-9e8e-42fca731505b"} : get policies decisions from WKC failed: Post "wkc-connector:50090/getPoliciesDecisions": unsupported protocol scheme "wkc-connector"
2021-08-25T06:00:18.743Z	INFO	controllers.FybrikApplication	Reconciled with errors: An error was received for asset {"asset_id": "b00afa87-fc56-4a60-9bd6-ab11a9f1c266", "catalog_id": "afbdd6c9-8cb3-4634-9e8e-42fca731505b"} . If the error persists, please contact an operator.Error description: get policies decisions from WKC failed: Post "wkc-connector:50090/getPoliciesDecisions": unsupported protocol scheme "wkc-connector"	{"fybrikapplication": "fybrik-latha/fyapp-wkc-deny"}
[root@pipit1 cpdcluster]# 
```
Signed-off-by: Rohith D Vallam <rovallam@in.ibm.com>