### PR TITLE
Set Deny state for an asset with an unsupported data store type

### DIFF
--- a/manager/apis/app/v1alpha1/fybrikapplication_types.go
+++ b/manager/apis/app/v1alpha1/fybrikapplication_types.go
@@ -92,13 +92,14 @@ type FybrikApplicationSpec struct {
 
 // ErrorMessages that are reported to the user
 const (
-	InvalidAssetID              string = "The asset does not exist."
-	ReadAccessDenied            string = "Governance policies forbid access to the data."
-	CopyNotAllowed              string = "Copy of the data is required but can not be done according to the governance policies."
-	WriteNotAllowed             string = "Governance policies forbid writing of the data."
-	ModuleNotFound              string = "No module has been registered"
-	InsufficientStorage         string = "No bucket was provisioned for implicit copy"
-	InvalidClusterConfiguration string = "Cluster configuration does not support the requirements."
+	InvalidAssetID              string = "the asset does not exist"
+	ReadAccessDenied            string = "governance policies forbid access to the data"
+	CopyNotAllowed              string = "copy of the data is required but can not be done according to the governance policies"
+	WriteNotAllowed             string = "governance policies forbid writing of the data"
+	ModuleNotFound              string = "no module has been registered"
+	InsufficientStorage         string = "no bucket was provisioned for implicit copy"
+	InvalidClusterConfiguration string = "cluster configuration does not support the requirements"
+	InvalidAssetDataStore       string = "the asset data store is not supported"
 )
 
 // Condition indices are static. Conditions always present in the status.

--- a/manager/controllers/app/fybrikapplication_controller.go
+++ b/manager/controllers/app/fybrikapplication_controller.go
@@ -7,11 +7,12 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
+	"time"
+
 	"fybrik.io/fybrik/manager/controllers"
 	"fybrik.io/fybrik/pkg/environment"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"strings"
-	"time"
 
 	connectors "fybrik.io/fybrik/pkg/connectors/clients"
 	pb "fybrik.io/fybrik/pkg/connectors/protobuf"
@@ -343,7 +344,7 @@ func (r *FybrikApplicationReconciler) reconcile(applicationContext *api.FybrikAp
 		requirements = append(requirements, req)
 	}
 	// check if can proceed
-	if getErrorMessages(applicationContext) != "" {
+	if len(requirements) == 0 {
 		return ctrl.Result{}, nil
 	}
 
@@ -522,7 +523,7 @@ func AnalyzeError(application *api.FybrikApplication, assetID string, err error)
 		return
 	}
 	switch err.Error() {
-	case api.InvalidAssetID, api.ReadAccessDenied, api.CopyNotAllowed, api.WriteNotAllowed:
+	case api.InvalidAssetID, api.ReadAccessDenied, api.CopyNotAllowed, api.WriteNotAllowed, api.InvalidAssetDataStore:
 		setDenyCondition(application, assetID, err.Error())
 	default:
 		setErrorCondition(application, assetID, err.Error())

--- a/manager/controllers/app/modules/moduleinterface.go
+++ b/manager/controllers/app/modules/moduleinterface.go
@@ -247,12 +247,9 @@ func CatalogDatasetToDataDetails(response *pb.CatalogDatasetInfo) (*DataDetails,
 	if details == nil {
 		return nil, errors.New("no metadata found for " + response.DatasetId)
 	}
-	protocol, err := utils.GetProtocol(details)
-	if err != nil {
-		return nil, err
-	}
 	format := details.DataFormat
 	connection := serde.NewArbitrary(details.DataStore)
+	protocol, err := utils.GetProtocol(details)
 
 	return &DataDetails{
 		Name: details.Name,
@@ -263,5 +260,5 @@ func CatalogDatasetToDataDetails(response *pb.CatalogDatasetInfo) (*DataDetails,
 		Geography:  details.Geo,
 		Connection: *connection,
 		Metadata:   details.Metadata,
-	}, nil
+	}, err
 }

--- a/manager/controllers/mockup/datacatalog.go
+++ b/manager/controllers/mockup/datacatalog.go
@@ -161,6 +161,19 @@ func NewTestCatalog() *DataCatalogDummy {
 			Metadata: &pb.DatasetMetadata{},
 		},
 	}
+	dummyCatalog.dataDetails["local"] = pb.CatalogDatasetInfo{
+		DatasetId: "local",
+		Details: &pb.DatasetDetails{
+			Name:       "local file",
+			DataFormat: "csv",
+			Geo:        "theshire",
+			DataStore: &pb.DataStore{
+				Type: pb.DataStore_LOCAL,
+				Name: "file.csv",
+			},
+			Metadata: &pb.DatasetMetadata{DatasetTags: []string{"PI"}},
+		},
+	}
 
 	return &dummyCatalog
 }

--- a/manager/controllers/utils/utils.go
+++ b/manager/controllers/utils/utils.go
@@ -9,10 +9,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	app "fybrik.io/fybrik/manager/apis/app/v1alpha1"
-	dc "fybrik.io/fybrik/pkg/connectors/protobuf"
 	"runtime"
 	"sort"
+
+	app "fybrik.io/fybrik/manager/apis/app/v1alpha1"
+	dc "fybrik.io/fybrik/pkg/connectors/protobuf"
 )
 
 // GetProtocol returns the existing data protocol
@@ -25,7 +26,7 @@ func GetProtocol(info *dc.DatasetDetails) (string, error) {
 	case dc.DataStore_DB2:
 		return app.JdbcDb2, nil
 	}
-	return "", errors.New("unknown protocol")
+	return "", errors.New(app.InvalidAssetDataStore)
 }
 
 // IsTransformation returns true if the data transformation is required

--- a/manager/testdata/unittests/fybrikapplication-appInfoErrors.yaml
+++ b/manager/testdata/unittests/fybrikapplication-appInfoErrors.yaml
@@ -7,7 +7,7 @@ metadata:
     app: kf-notebook
 spec:
   selector:
-    clusterName: hobbiton
+    clusterName: thegreendragon
     workloadSelector:
       matchLabels:
         app: kf-notebook

--- a/manager/testdata/unittests/fybrikapplication-interfaceErrors.yaml
+++ b/manager/testdata/unittests/fybrikapplication-interfaceErrors.yaml
@@ -7,7 +7,7 @@ metadata:
     app: kf-notebook
 spec:
   selector:
-    clusterName: hobbiton
+    clusterName: thegreendragon
     workloadSelector:
       matchLabels:
         app: kf-notebook

--- a/manager/testdata/unittests/fybrikapplication-validForBase.yaml
+++ b/manager/testdata/unittests/fybrikapplication-validForBase.yaml
@@ -6,7 +6,7 @@ metadata:
     app: kf-notebook
 spec:
   selector:
-    clusterName: hobbiton
+    clusterName: thegreendragon
     workloadSelector:
       matchLabels:
         app: kf-notebook

--- a/samples/gui/README.md
+++ b/samples/gui/README.md
@@ -43,7 +43,7 @@ curl -X POST -i http://localhost:8080/v1/dma/fybrikapplication --data '{"apiVers
 ## Run server locally - run vault as well as REST API server
 
 export KUBECONFIG=$HOME/.kube/config
-export GEOGRAPHY=hobbiton
+export GEOGRAPHY=theshire
 make build
 ./datauserserver
 

--- a/samples/kubeflow/fybrikapplication.yaml
+++ b/samples/kubeflow/fybrikapplication.yaml
@@ -6,7 +6,7 @@ metadata:
     app: kf-notebook
 spec:
   selector:
-    clusterName: hobbiton
+    clusterName: thegreendragon
     workloadSelector:
       matchLabels:
         app: kf-notebook


### PR DESCRIPTION
Signed-off-by: Shlomit Koyfman <shlomitk@il.ibm.com>
Fixes https://github.com/fybrik/fybrik/issues/798

An asset with an unsupported data store type was assigned Error, which caused more reconciles instead of assigning Deny and continuing with valid assets.

Minor fixes of formatting problems, incorrect cluster names, ...