### PR TITLE
Blueprint namespace configurable; remove hardcoded system namespace; restrict namespace for fybrikapplication

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,6 +143,7 @@ jobs:
         image_source_repo_username: fake@fake.com 
         GH_TOKEN: fake
       run: pushd hack/tools/ && ./create_kind.sh && docker info && popd && . pipeline/source-external.sh && skip_tests=false kind=true github_workspace=${{ github.workspace }} pipeline/bootstrap-pipeline.sh fybrik-system
+
   push_images:
     name: Push images
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ third_party/egeria/egeria
 # Local development
 .env
 __debug_bin
+
+pipeline/custom_*
+pipeline/custom-pipeline.yaml

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ deploy: $(TOOLBIN)/kubectl $(TOOLBIN)/helm
                --namespace $(KUBE_NAMESPACE) --wait --timeout 120s
 
 .PHONY: test
+test: export BLUEPRINT_NAMESPACE?=fybrik-blueprints
+test: export CONTROLLER_NAMESPACE?=fybrik-system
 test:
 	$(MAKE) -C manager pre-test
 	go test -v ./...

--- a/charts/fybrik/templates/_helpers.tpl
+++ b/charts/fybrik/templates/_helpers.tpl
@@ -99,3 +99,15 @@ certmanager.k8s.io/v1alpha1
 cert-manager.io/v1alpha2
 {{- end -}}
 {{- end -}}
+
+{{/*
+Get blueprints namespace
+*/}}
+{{- define "fybrik.getBlueprintNamespace" -}}
+{{- if .Values.blueprintNamespace -}}
+{{- .Values.blueprintNamespace -}}
+{{- else -}}
+{{- "fybrik-blueprints" -}}
+{{- end -}}
+{{- end -}}
+

--- a/charts/fybrik/templates/batchtransfer-rb.yaml
+++ b/charts/fybrik/templates/batchtransfer-rb.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: batchtransfer-rb
-  namespace: fybrik-blueprints
+  namespace: {{ .Values.blueprintNamespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/fybrik/templates/batchtransfer-role.yaml
+++ b/charts/fybrik/templates/batchtransfer-role.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.worker.enabled }}
-# Role batchtransfer-editor allows managing batchtransfers
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/charts/fybrik/templates/blueprints-rb.yaml
+++ b/charts/fybrik/templates/blueprints-rb.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: blueprints-rb
-  namespace: fybrik-blueprints
+  namespace: {{ .Values.blueprintNamespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -13,3 +13,4 @@ subjects:
   name: {{ .Values.manager.serviceAccount.name | default "default" }}
   namespace: {{ .Release.Namespace }}
 {{- end }}
+

--- a/charts/fybrik/templates/fybrik-admin-rb.yaml
+++ b/charts/fybrik/templates/fybrik-admin-rb.yaml
@@ -1,17 +1,16 @@
 {{- if include "fybrik.isEnabled" (tuple .Values.manager.enabled (or .Values.coordinator.enabled .Values.worker.enabled)) }}
-{{- if and  .Values.clusterScoped .Values.manager.prometheus }}
+{{- if not (.Values.clusterScoped) }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
-  name: {{ template "fybrik.fullname" . }}-proxy-crb
+  name: {{ template "fybrik.fullname" . }}-admin-rb
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ template "fybrik.fullname" . }}-proxy-cr
+  kind: Role
+  name: {{ template "fybrik.fullname" . }}-admin-role
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.manager.serviceAccount.name | default "default" }}
   namespace: {{ .Release.Namespace }}
 {{- end }}
 {{- end }}
-

--- a/charts/fybrik/templates/fybrik-admin-role.yaml
+++ b/charts/fybrik/templates/fybrik-admin-role.yaml
@@ -1,0 +1,121 @@
+{{- if include "fybrik.isEnabled" (tuple .Values.manager.enabled (or .Values.coordinator.enabled .Values.worker.enabled)) }}
+{{- if not (.Values.clusterScoped) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "fybrik.fullname" . }}-admin-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - secrets
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - leases
+  - leases/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - app.fybrik.io
+  resources:
+  - blueprints
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - app.fybrik.io
+  resources:
+  - blueprints/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - app.fybrik.io
+  resources:
+  - fybrikapplications
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - app.fybrik.io
+  resources:
+  - fybrikapplications/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - app.fybrik.io
+  resources:
+  - plotters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - app.fybrik.io
+  resources:
+  - plotters/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - app.fybrik.io
+  resources:
+  - fybrikstorageaccounts
+  - fybrikmodules
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - com.ie.ibm.hpsys
+  resources:
+  - datasets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+{{- end }}
+{{- end }}

--- a/charts/fybrik/templates/fybrik-blueprints-ns.yaml
+++ b/charts/fybrik/templates/fybrik-blueprints-ns.yaml
@@ -3,6 +3,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: fybrik-blueprints
+  name: {{ .Values.blueprintNamespace }}
 {{- end }}
 {{- end }}

--- a/charts/fybrik/templates/fybrik-blueprints-rb.yaml
+++ b/charts/fybrik/templates/fybrik-blueprints-rb.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "fybrik.fullname" . }}-blueprints-rb
-  namespace: fybrik-blueprints
+  namespace: {{ .Values.blueprintNamespace }}
   labels:
     {{- include "fybrik.labels" . | nindent 4 }}
 roleRef:

--- a/charts/fybrik/templates/fybrik-blueprints-role.yaml
+++ b/charts/fybrik/templates/fybrik-blueprints-role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "fybrik.fullname" . }}-blueprints-role
-  namespace: fybrik-blueprints
+  namespace: {{ .Values.blueprintNamespace }}
 rules:
 - apiGroups:
   - '*'

--- a/charts/fybrik/templates/manager-auth-proxy-cr.yaml
+++ b/charts/fybrik/templates/manager-auth-proxy-cr.yaml
@@ -1,5 +1,5 @@
 {{- if include "fybrik.isEnabled" (tuple .Values.manager.enabled (or .Values.coordinator.enabled .Values.worker.enabled)) }}
-{{- if .Values.clusterScoped }}
+{{- if and  .Values.clusterScoped .Values.manager.prometheus }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/fybrik/templates/manager-auth-proxy-service.yaml
+++ b/charts/fybrik/templates/manager-auth-proxy-service.yaml
@@ -1,4 +1,5 @@
 {{- if include "fybrik.isEnabled" (tuple .Values.manager.enabled (or .Values.coordinator.enabled .Values.worker.enabled)) }}
+{{- if and  .Values.clusterScoped .Values.manager.prometheus }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -15,4 +16,4 @@ spec:
     control-plane: controller-manager
     {{- include "fybrik.selectorLabels" . | nindent 4 }}
 {{- end }}
-
+{{- end }}

--- a/charts/fybrik/templates/manager-deployment.yaml
+++ b/charts/fybrik/templates/manager-deployment.yaml
@@ -43,6 +43,7 @@ spec:
           - TCP4-LISTEN:5000,fork
           - TCP4:kind-registry:5000
         {{- end }}
+        {{- if and .Values.clusterScoped .Values.manager.prometheus }}
         - name: kube-rbac-proxy
           image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
           args:
@@ -53,6 +54,7 @@ spec:
           ports:
           - containerPort: 8443
             name: https
+        {{- end }}
         - name: manager
           image: {{ include "fybrik.image" ( tuple $ .Values.manager ) }}
           imagePullPolicy: {{ .Values.manager.imagePullPolicy | default .Values.global.imagePullPolicy }}
@@ -60,16 +62,18 @@ spec:
             {{- if .Values.manager.overrideArgs }}
             {{- toYaml .Values.manager.overrideArgs | nindent 12 }}
             {{- else }}
+            {{- if and .Values.clusterScoped .Values.manager.prometheus }}
             - "--metrics-bind-addr=127.0.0.1:8080"
+            {{- end }}
             - "--leader-elect"
-            {{- if .Values.coordinator.enabled}}
+            {{- if .Values.coordinator.enabled }}
             - "--enable-application-controller"
             - "--enable-plotter-controller"
-            {{- end}}
-            {{- if .Values.worker.enabled}}
+            {{- end }}
+            {{- if .Values.worker.enabled }}
             - "--enable-blueprint-controller"
             - "--enable-motion-controller"
-            {{- end}}
+            {{- end }}
             {{- end }}
           envFrom:
             - configMapRef:
@@ -80,18 +84,35 @@ spec:
             {{- end }}
           env:
             - name: ENABLE_WEBHOOKS
+            {{- if .Values.clusterScoped }} 
               value: "true"
+            {{- else }}
+              value: "false"
+            {{- end }}
+
+            - name: BLUEPRINT_NAMESPACE
+              value: {{ include "fybrik.getBlueprintNamespace" . }}
+
+            {{- if .Values.applicationNamespace }}
+            - name: APPLICATION_NAMESPACE
+              value: {{ .Values.applicationNamespace }}
+            {{- end }}
+
             {{- if .Values.manager.extraEnvs }}
             {{- toYaml .Values.manager.extraEnvs | nindent 12 }}
             {{- end }}
+          {{- if .Values.clusterScoped }} 
           ports:
             - containerPort: 9443
               name: webhook-server
               protocol: TCP
+          {{- end }}
           volumeMounts:
+            {{- if .Values.clusterScoped }}
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: cert
-              readOnly: true
+              readOnly: true  
+            {{- end }}     
             - mountPath: /tmp/taxonomy
               name: fybrik-taxonomy
           securityContext:
@@ -100,10 +121,13 @@ spec:
             {{- toYaml .Values.manager.resources | nindent 12 }}
       terminationGracePeriodSeconds: 10
       volumes:
+        {{- if .Values.clusterScoped }}
         - name: cert
           secret:
             defaultMode: 420
             secretName: webhook-server-cert
+        {{- end }}
+
         - name: fybrik-taxonomy
           configMap:
             name: fybrik-taxonomy-config

--- a/charts/fybrik/templates/manager-prometheus-monitor.yaml
+++ b/charts/fybrik/templates/manager-prometheus-monitor.yaml
@@ -1,5 +1,5 @@
 {{- if include "fybrik.isEnabled" (tuple .Values.manager.enabled (or .Values.coordinator.enabled .Values.worker.enabled)) }}
-{{- if .Values.manager.prometheus }}
+{{- if and .Values.clusterScoped .Values.manager.prometheus }}
 # Prometheus Monitor Service (Metrics)
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/charts/fybrik/templates/streamtransfer-rb.yaml
+++ b/charts/fybrik/templates/streamtransfer-rb.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: streamtransfer-rb
-  namespace: fybrik-blueprints
+  namespace: {{ .Values.blueprintNamespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/fybrik/templates/webhook-certificates.yaml
+++ b/charts/fybrik/templates/webhook-certificates.yaml
@@ -1,4 +1,5 @@
 {{- if include "fybrik.isEnabled" (tuple .Values.manager.enabled (or .Values.coordinator.enabled .Values.worker.enabled)) }}
+{{- if .Values.clusterScoped }}
 apiVersion: {{ include "fybrik.certManagerApiVersion" . }}
 kind: Issuer
 metadata:
@@ -21,4 +22,5 @@ spec:
     kind: Issuer
     name: selfsigned-issuer
   secretName: webhook-server-cert
+{{- end }}
 {{- end }}

--- a/charts/fybrik/templates/webhook-service.yaml
+++ b/charts/fybrik/templates/webhook-service.yaml
@@ -1,4 +1,5 @@
 {{- if include "fybrik.isEnabled" (tuple .Values.manager.enabled (or .Values.coordinator.enabled .Values.worker.enabled)) }}
+{{- if .Values.clusterScoped }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -10,4 +11,5 @@ spec:
     targetPort: 9443
   selector:
     control-plane: controller-manager
+{{- end }}
 {{- end }}

--- a/charts/fybrik/values.yaml
+++ b/charts/fybrik/values.yaml
@@ -13,6 +13,11 @@ fullnameOverride: ""
 
 clusterScoped: true
 
+blueprintNamespace: "fybrik-blueprints"
+
+# Set if need to only watch for FybrikApplication from a specific namespace
+#applicationNamespace: ""
+
 # Taxonomy file for taxonomy ConfigMap
 taxonomyOverride: ""
 

--- a/charts/vault/templates/post-pod-creation-cm.yaml
+++ b/charts/vault/templates/post-pod-creation-cm.yaml
@@ -25,7 +25,7 @@ data:
       }
       EOF
       # allow modules running in fybrik-blueprints namespace to access dataset credentials
-      vault write auth/kubernetes/role/module bound_service_account_names="*" bound_service_account_namespaces="fybrik-blueprints" policies="allow-all-dataset-creds" ttl=24h
+      vault write auth/kubernetes/role/module bound_service_account_names="*" bound_service_account_namespaces="{{ .Values.blueprintNamespace }}" policies="allow-all-dataset-creds" ttl=24h
       # enable userpass auth method
       vault auth enable userpass
       vault write auth/userpass/users/data_provider password=password policies="allow-all-dataset-creds"

--- a/charts/vault/values.yaml
+++ b/charts/vault/values.yaml
@@ -9,4 +9,4 @@ plugins:
     namespaces: 
       #- fybrik-notebook-sample
       #- fybrik-system
-    
+  blueprintNamespace: "fybrik-blueprints"    

--- a/manager/Makefile
+++ b/manager/Makefile
@@ -9,8 +9,10 @@ include $(ROOT_DIR)/hack/make-rules/tools.mk
 DOCKER_NAME ?= manager
 GO_OUTPUT_FILE = manager
 KUBE_NAMESPACE ?= fybrik-system
+CONTROLLER_NAMESPACE ?= ${KUBE_NAMESPACE}
 include $(ROOT_DIR)/hack/make-rules/docker.mk
 include $(ROOT_DIR)/hack/make-rules/verify.mk
+
 
 pre-test: generate manifests $(TOOLBIN)/etcd $(TOOLBIN)/kube-apiserver
 	mkdir /tmp/taxonomy || true                                                                                                                          
@@ -22,8 +24,10 @@ pre-test: generate manifests $(TOOLBIN)/etcd $(TOOLBIN)/kube-apiserver
 	go run ../main.go taxonomy compile --out testdata/unittests/sampletaxonomy/taxonomy.json --base ../config/taxonomy/base/base.yaml ../config/taxonomy/example/application/appinfo.yaml ../config/taxonomy/example/application/interface.yaml ../config/taxonomy/example/catalog/locations.yaml ../config/taxonomy/example/catalog/tags.yaml ../config/taxonomy/example/module/actions.yaml 
 
 # Run tests
+test: export BLUEPRINT_NAMESPACE?=fybrik-blueprints
+test: export CONTROLLER_NAMESPACE?=fybrik-system
 test: pre-test
-	go test ./... -coverprofile cover.out
+	go test ./... -v  -coverprofile cover.out
 
 # Build manager binary
 manager: generate fmt vet
@@ -61,7 +65,7 @@ docker-build: generate source-build
 
 .PHONY: wait_for_manager
 wait_for_manager: $(TOOLBIN)/kubectl
-	$(TOOLBIN)/kubectl wait --for=condition=available -n ${KUBE_NAMESPACE} deployment/manager --timeout=120s
+	$(TOOLBIN)/kubectl wait --for=condition=available -n ${CONTROLLER_NAMESPACE} deployment/manager --timeout=120s
 
 .PHONY: run-integration-tests
 run-integration-tests: export DOCKER_HOSTNAME?=localhost:5000

--- a/manager/controllers/app/blueprint_controller.go
+++ b/manager/controllers/app/blueprint_controller.go
@@ -6,11 +6,12 @@ package app
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
+
 	"fybrik.io/fybrik/manager/controllers"
 	"fybrik.io/fybrik/pkg/environment"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"strings"
-	"time"
 
 	"emperror.dev/errors"
 	app "fybrik.io/fybrik/manager/apis/app/v1alpha1"
@@ -295,12 +296,16 @@ func (r *BlueprintReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// 'UpdateFunc' and 'CreateFunc' used to judge if the event came from within the blueprint's namespace.
 	// If that is true, the event will be processed by the reconciler.
 	// If it's not then it is a rogue event created by someone outside of the control plane.
+
+	blueprintNamespace := utils.GetBlueprintNamespace()
+	r.Log.Info("blueprint namespace: " + blueprintNamespace)
+
 	p := predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
-			return e.Object.GetNamespace() == BlueprintNamespace
+			return e.Object.GetNamespace() == blueprintNamespace
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return e.ObjectOld.GetNamespace() == BlueprintNamespace
+			return e.ObjectOld.GetNamespace() == blueprintNamespace
 		},
 	}
 

--- a/manager/controllers/app/blueprint_controller_unit_test.go
+++ b/manager/controllers/app/blueprint_controller_unit_test.go
@@ -5,6 +5,7 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"testing"
 
@@ -38,12 +39,17 @@ func readBlueprint(f string) (*app.Blueprint, error) {
 }
 
 func TestBlueprintReconcile(t *testing.T) {
+
+	blueprintNamespace := utils.GetBlueprintNamespace()
+	fmt.Printf("Blueprint controller unit test: Using blueprint namespace: %s\n", blueprintNamespace)
+
 	t.Parallel()
 	g := gomega.NewGomegaWithT(t)
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 
 	blueprint, err := readBlueprint("../../testdata/blueprint.yaml")
 	g.Expect(err).To(gomega.BeNil(), "Cannot read blueprint file for test")
+	blueprint.Namespace = blueprintNamespace
 
 	// Objects to track in the fake client.
 	objs := []runtime.Object{

--- a/manager/controllers/app/blueprint_controller_unit_test.go
+++ b/manager/controllers/app/blueprint_controller_unit_test.go
@@ -39,7 +39,6 @@ func readBlueprint(f string) (*app.Blueprint, error) {
 }
 
 func TestBlueprintReconcile(t *testing.T) {
-
 	blueprintNamespace := utils.GetBlueprintNamespace()
 	fmt.Printf("Blueprint controller unit test: Using blueprint namespace: %s\n", blueprintNamespace)
 

--- a/manager/controllers/app/fybrikapplication_controller.go
+++ b/manager/controllers/app/fybrikapplication_controller.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 
 	"strings"
-	"time
+	"time"
 	"os"
 
 	"fybrik.io/fybrik/manager/controllers"

--- a/manager/controllers/app/fybrikapplication_controller_test.go
+++ b/manager/controllers/app/fybrikapplication_controller_test.go
@@ -5,16 +5,18 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1alpha1 "fybrik.io/fybrik/manager/apis/app/v1alpha1"
+	"fybrik.io/fybrik/manager/controllers/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const timeout = time.Second * 30
@@ -22,11 +24,17 @@ const interval = time.Millisecond * 100
 
 var _ = Describe("FybrikApplication Controller", func() {
 	Context("FybrikApplication", func() {
+
+		controllerNamespace := utils.GetControllerNamespace()
+		fmt.Printf("FybrikApplication: controller namespace: %s\n", controllerNamespace)
+
 		BeforeEach(func() {
 			// Add any setup steps that needs to be executed before each test
 			module := &apiv1alpha1.FybrikModule{}
 			Expect(readObjectFromFile("../../testdata/e2e/module-read.yaml", module)).ToNot(HaveOccurred())
+			module.Namespace = controllerNamespace
 			application := &apiv1alpha1.FybrikApplication{}
+
 			Expect(readObjectFromFile("../../testdata/e2e/fybrikapplication.yaml", application)).ToNot(HaveOccurred())
 			_ = k8sClient.Delete(context.Background(), application)
 			_ = k8sClient.Delete(context.Background(), module)
@@ -46,7 +54,10 @@ var _ = Describe("FybrikApplication Controller", func() {
 				Expect(k8sClient.Create(context.TODO(), secret1)).NotTo(HaveOccurred(), "a secret could not be created")
 				secret2 := &corev1.Secret{Type: corev1.SecretTypeOpaque, StringData: map[string]string{"password": "123"}}
 				secret2.Name = "test-secret"
-				secret2.Namespace = BlueprintNamespace
+
+				blueprintNamespace := utils.GetBlueprintNamespace()
+				fmt.Printf("Application test using blueprint namespace: %s\n", blueprintNamespace)
+				secret2.Namespace = blueprintNamespace
 				Expect(k8sClient.Create(context.TODO(), secret2)).NotTo(HaveOccurred(), "a secret could not be created")
 				secretList := &corev1.SecretList{}
 				Expect(k8sClient.List(context.Background(), secretList)).NotTo(HaveOccurred())
@@ -69,16 +80,20 @@ var _ = Describe("FybrikApplication Controller", func() {
 		})
 		It("Test end-to-end for FybrikApplication", func() {
 			connector := os.Getenv("USE_MOCKUP_CONNECTOR")
+			fmt.Printf("Connector:  %s\n", connector)
 			if len(connector) > 0 && connector != "true" {
 				Skip("Skipping test when not running with mockup connector!")
 			}
 			module := &apiv1alpha1.FybrikModule{}
 			Expect(readObjectFromFile("../../testdata/e2e/module-read.yaml", module)).ToNot(HaveOccurred())
 			moduleKey := client.ObjectKeyFromObject(module)
+			module.Namespace = controllerNamespace
 			application := &apiv1alpha1.FybrikApplication{}
+
 			Expect(readObjectFromFile("../../testdata/e2e/fybrikapplication.yaml", application)).ToNot(HaveOccurred())
 			applicationKey := client.ObjectKeyFromObject(application)
-
+			fmt.Printf("Module:  %v\n", module.Namespace)
+			fmt.Printf("Application:  %v\n", application.Namespace)
 			// Create FybrikApplication and FybrikModule
 			Expect(k8sClient.Create(context.Background(), module)).Should(Succeed())
 			Expect(k8sClient.Create(context.Background(), application)).Should(Succeed())
@@ -87,10 +102,10 @@ var _ = Describe("FybrikApplication Controller", func() {
 			defer func() {
 				application := &apiv1alpha1.FybrikApplication{ObjectMeta: metav1.ObjectMeta{Namespace: applicationKey.Namespace, Name: applicationKey.Name}}
 				_ = k8sClient.Get(context.Background(), applicationKey, application)
-				_ = k8sClient.Delete(context.Background(), application)
+				//_ = k8sClient.Delete(context.Background(), application)
 				module := &apiv1alpha1.FybrikApplication{ObjectMeta: metav1.ObjectMeta{Namespace: moduleKey.Namespace, Name: moduleKey.Name}}
 				_ = k8sClient.Get(context.Background(), moduleKey, module)
-				_ = k8sClient.Delete(context.Background(), module)
+				//_ = k8sClient.Delete(context.Background(), module)
 			}()
 
 			By("Expecting application to be created")
@@ -122,9 +137,12 @@ var _ = Describe("FybrikApplication Controller", func() {
 				return application.Status.Ready
 			}, timeout, interval).Should(BeTrue(), "FybrikApplication is not ready after timeout!")
 
+			blueprintNamespace := utils.GetBlueprintNamespace()
+			fmt.Printf("blueprint namespace fybrikapp: %s\n", blueprintNamespace)
+
 			By("Status should contain the details of the endpoint")
 			Expect(len(application.Status.AssetStates)).To(Equal(1))
-			fqdn := "test-app-e2e-default-read-module-test-e2e-e24d69b99a.fybrik-blueprints.svc.cluster.local"
+			fqdn := "test-app-e2e-default-read-module-test-e2e-e24d69b99a." + blueprintNamespace + ".svc.cluster.local"
 			Expect(application.Status.AssetStates["s3/redact-dataset"].Endpoint).To(Equal(apiv1alpha1.EndpointSpec{
 				Hostname: fqdn,
 				Port:     80,

--- a/manager/controllers/app/fybrikapplication_controller_test.go
+++ b/manager/controllers/app/fybrikapplication_controller_test.go
@@ -102,10 +102,10 @@ var _ = Describe("FybrikApplication Controller", func() {
 			defer func() {
 				application := &apiv1alpha1.FybrikApplication{ObjectMeta: metav1.ObjectMeta{Namespace: applicationKey.Namespace, Name: applicationKey.Name}}
 				_ = k8sClient.Get(context.Background(), applicationKey, application)
-				//_ = k8sClient.Delete(context.Background(), application)
+				// _ = k8sClient.Delete(context.Background(), application)
 				module := &apiv1alpha1.FybrikApplication{ObjectMeta: metav1.ObjectMeta{Namespace: moduleKey.Namespace, Name: moduleKey.Name}}
 				_ = k8sClient.Get(context.Background(), moduleKey, module)
-				//_ = k8sClient.Delete(context.Background(), module)
+				// _ = k8sClient.Delete(context.Background(), module)
 			}()
 
 			By("Expecting application to be created")

--- a/manager/controllers/app/fybrikapplication_controller_unit_test.go
+++ b/manager/controllers/app/fybrikapplication_controller_unit_test.go
@@ -5,6 +5,7 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"testing"
 	"time"
@@ -87,7 +88,9 @@ func TestFybrikApplicationControllerCSVCopyAndRead(t *testing.T) {
 	readModule := &app.FybrikModule{}
 	copyModule := &app.FybrikModule{}
 	g.Expect(readObjectFromFile("../../testdata/unittests/implicit-copy-batch-module-csv.yaml", copyModule)).NotTo(gomega.HaveOccurred())
+	copyModule.Namespace = utils.GetControllerNamespace()
 	g.Expect(readObjectFromFile("../../testdata/unittests/module-read-csv.yaml", readModule)).NotTo(gomega.HaveOccurred())
+	readModule.Namespace = utils.GetControllerNamespace()
 
 	// Create modules in fake K8s agent
 	g.Expect(cl.Create(context.Background(), copyModule)).NotTo(gomega.HaveOccurred())
@@ -96,9 +99,11 @@ func TestFybrikApplicationControllerCSVCopyAndRead(t *testing.T) {
 	// Create storage account
 	dummySecret := &corev1.Secret{}
 	g.Expect(readObjectFromFile("../../testdata/unittests/credentials-theshire.yaml", dummySecret)).NotTo(gomega.HaveOccurred())
+	dummySecret.Namespace = utils.GetControllerNamespace()
 	g.Expect(cl.Create(context.Background(), dummySecret)).NotTo(gomega.HaveOccurred())
 	account := &app.FybrikStorageAccount{}
 	g.Expect(readObjectFromFile("../../testdata/unittests/account-theshire.yaml", account)).NotTo(gomega.HaveOccurred())
+	account.Namespace = utils.GetControllerNamespace()
 	g.Expect(cl.Create(context.Background(), account)).NotTo(gomega.HaveOccurred())
 
 	r := createTestFybrikApplicationController(cl, s)
@@ -122,8 +127,11 @@ func TestFybrikApplicationControllerCSVCopyAndRead(t *testing.T) {
 	g.Expect(err).To(gomega.BeNil(), "Cannot fetch fybrikapplication")
 	g.Expect(application.Status.Generated).NotTo(gomega.BeNil())
 
+	controllerNamespace := utils.GetControllerNamespace()
+	fmt.Printf("M4DApplication unit test: controller namespace " + controllerNamespace)
+
 	plotterObjectKey := types.NamespacedName{
-		Namespace: "fybrik-system",
+		Namespace: controllerNamespace,
 		Name:      "notebook-default",
 	}
 	plotter := &app.Plotter{}
@@ -253,6 +261,7 @@ func TestNoReadPath(t *testing.T) {
 	// Read module
 	readModule := &app.FybrikModule{}
 	g.Expect(readObjectFromFile("../../testdata/unittests/module-read-parquet.yaml", readModule)).NotTo(gomega.HaveOccurred())
+	readModule.Namespace = utils.GetControllerNamespace()
 	g.Expect(cl.Create(context.TODO(), readModule)).NotTo(gomega.HaveOccurred(), "the read module could not be created")
 	// Create a FybrikApplicationReconciler object with the scheme and fake client.
 	r := createTestFybrikApplicationController(cl, s)
@@ -315,9 +324,11 @@ func TestWrongCopyModule(t *testing.T) {
 	// Read module
 	readModule := &app.FybrikModule{}
 	g.Expect(readObjectFromFile("../../testdata/unittests/module-read-parquet.yaml", readModule)).NotTo(gomega.HaveOccurred())
+	readModule.Namespace = utils.GetControllerNamespace()
 	g.Expect(cl.Create(context.TODO(), readModule)).NotTo(gomega.HaveOccurred(), "the read module could not be created")
 	copyModule := &app.FybrikModule{}
 	g.Expect(readObjectFromFile("../../testdata/unittests/copy-db2-parquet.yaml", copyModule)).NotTo(gomega.HaveOccurred())
+	copyModule.Namespace = utils.GetControllerNamespace()
 	g.Expect(cl.Create(context.TODO(), copyModule)).NotTo(gomega.HaveOccurred(), "the copy module could not be created")
 	// Create a FybrikApplicationReconciler object with the scheme and fake client.
 	r := createTestFybrikApplicationController(cl, s)
@@ -372,9 +383,11 @@ func TestActionSupport(t *testing.T) {
 	// Read module
 	readModule := &app.FybrikModule{}
 	g.Expect(readObjectFromFile("../../testdata/unittests/module-read-parquet.yaml", readModule)).NotTo(gomega.HaveOccurred())
+	readModule.Namespace = utils.GetControllerNamespace()
 	g.Expect(cl.Create(context.TODO(), readModule)).NotTo(gomega.HaveOccurred(), "the read module could not be created")
 	copyModule := &app.FybrikModule{}
 	g.Expect(readObjectFromFile("../../testdata/unittests/copy-db2-parquet-no-transforms.yaml", copyModule)).NotTo(gomega.HaveOccurred())
+	copyModule.Namespace = utils.GetControllerNamespace()
 	g.Expect(cl.Create(context.TODO(), copyModule)).NotTo(gomega.HaveOccurred(), "the copy module could not be created")
 	// Create a FybrikApplicationReconciler object with the scheme and fake client.
 	r := createTestFybrikApplicationController(cl, s)
@@ -442,16 +455,20 @@ func TestMultipleDatasets(t *testing.T) {
 	// Read module
 	readModule := &app.FybrikModule{}
 	g.Expect(readObjectFromFile("../../testdata/unittests/module-read-parquet.yaml", readModule)).NotTo(gomega.HaveOccurred())
+	readModule.Namespace = utils.GetControllerNamespace()
 	g.Expect(cl.Create(context.TODO(), readModule)).NotTo(gomega.HaveOccurred(), "the read module could not be created")
 	copyModule := &app.FybrikModule{}
 	g.Expect(readObjectFromFile("../../testdata/unittests/copy-db2-parquet.yaml", copyModule)).NotTo(gomega.HaveOccurred())
+	copyModule.Namespace = utils.GetControllerNamespace()
 	g.Expect(cl.Create(context.TODO(), copyModule)).NotTo(gomega.HaveOccurred(), "the copy module could not be created")
 	// Create storage account
 	dummySecret := &corev1.Secret{}
 	g.Expect(readObjectFromFile("../../testdata/unittests/credentials-theshire.yaml", dummySecret)).NotTo(gomega.HaveOccurred())
+	dummySecret.Namespace = utils.GetControllerNamespace()
 	g.Expect(cl.Create(context.Background(), dummySecret)).NotTo(gomega.HaveOccurred())
 	account := &app.FybrikStorageAccount{}
 	g.Expect(readObjectFromFile("../../testdata/unittests/account-theshire.yaml", account)).NotTo(gomega.HaveOccurred())
+	account.Namespace = utils.GetControllerNamespace()
 	g.Expect(cl.Create(context.Background(), account)).NotTo(gomega.HaveOccurred())
 
 	// Create a FybrikApplicationReconciler object with the scheme and fake client.
@@ -526,16 +543,20 @@ func TestMultipleRegions(t *testing.T) {
 	// Read module
 	readModule := &app.FybrikModule{}
 	g.Expect(readObjectFromFile("../../testdata/unittests/module-read-parquet.yaml", readModule)).NotTo(gomega.HaveOccurred())
+	readModule.Namespace = utils.GetControllerNamespace()
 	g.Expect(cl.Create(context.TODO(), readModule)).NotTo(gomega.HaveOccurred(), "the read module could not be created")
 	copyModule := &app.FybrikModule{}
 	g.Expect(readObjectFromFile("../../testdata/unittests/copy-csv-parquet.yaml", copyModule)).NotTo(gomega.HaveOccurred())
+	copyModule.Namespace = utils.GetControllerNamespace()
 	g.Expect(cl.Create(context.TODO(), copyModule)).NotTo(gomega.HaveOccurred(), "the copy module could not be created")
 	// Create storage account
 	dummySecret := &corev1.Secret{}
 	g.Expect(readObjectFromFile("../../testdata/unittests/credentials-theshire.yaml", dummySecret)).NotTo(gomega.HaveOccurred())
+	dummySecret.Namespace = utils.GetControllerNamespace()
 	g.Expect(cl.Create(context.Background(), dummySecret)).NotTo(gomega.HaveOccurred())
 	account := &app.FybrikStorageAccount{}
 	g.Expect(readObjectFromFile("../../testdata/unittests/account-theshire.yaml", account)).NotTo(gomega.HaveOccurred())
+	account.Namespace = utils.GetControllerNamespace()
 	g.Expect(cl.Create(context.Background(), account)).NotTo(gomega.HaveOccurred())
 
 	// Create a FybrikApplicationReconciler object with the scheme and fake client.
@@ -591,19 +612,24 @@ func TestCopyData(t *testing.T) {
 	cl := fake.NewFakeClientWithScheme(s, objs...)
 	copyModule := &app.FybrikModule{}
 	g.Expect(readObjectFromFile("../../testdata/unittests/implicit-copy-batch-module-csv.yaml", copyModule)).NotTo(gomega.HaveOccurred())
+	copyModule.Namespace = utils.GetControllerNamespace()
 	g.Expect(cl.Create(context.TODO(), copyModule)).NotTo(gomega.HaveOccurred(), "the copy module could not be created")
 	// Create storage accounts
 	secret1 := &corev1.Secret{}
 	g.Expect(readObjectFromFile("../../testdata/unittests/credentials-neverland.yaml", secret1)).NotTo(gomega.HaveOccurred())
+	secret1.Namespace = utils.GetControllerNamespace()
 	g.Expect(cl.Create(context.Background(), secret1)).NotTo(gomega.HaveOccurred())
 	account1 := &app.FybrikStorageAccount{}
 	g.Expect(readObjectFromFile("../../testdata/unittests/account-neverland.yaml", account1)).NotTo(gomega.HaveOccurred())
+	account1.Namespace = utils.GetControllerNamespace()
 	g.Expect(cl.Create(context.Background(), account1)).NotTo(gomega.HaveOccurred())
 	secret2 := &corev1.Secret{}
 	g.Expect(readObjectFromFile("../../testdata/unittests/credentials-theshire.yaml", secret2)).NotTo(gomega.HaveOccurred())
+	secret2.Namespace = utils.GetControllerNamespace()
 	g.Expect(cl.Create(context.Background(), secret2)).NotTo(gomega.HaveOccurred())
 	account2 := &app.FybrikStorageAccount{}
 	g.Expect(readObjectFromFile("../../testdata/unittests/account-theshire.yaml", account2)).NotTo(gomega.HaveOccurred())
+	account2.Namespace = utils.GetControllerNamespace()
 	g.Expect(cl.Create(context.Background(), account2)).NotTo(gomega.HaveOccurred())
 
 	// Create a FybrikApplicationReconciler object with the scheme and fake client.
@@ -665,14 +691,17 @@ func TestCopyDataNotAllowed(t *testing.T) {
 	cl := fake.NewFakeClientWithScheme(s, objs...)
 	copyModule := &app.FybrikModule{}
 	g.Expect(readObjectFromFile("../../testdata/unittests/implicit-copy-batch-module-csv.yaml", copyModule)).NotTo(gomega.HaveOccurred())
+	copyModule.Namespace = utils.GetControllerNamespace()
 	g.Expect(cl.Create(context.TODO(), copyModule)).NotTo(gomega.HaveOccurred(), "the copy module could not be created")
 
 	// Create storage account
 	dummySecret := &corev1.Secret{}
 	g.Expect(readObjectFromFile("../../testdata/unittests/credentials-theshire.yaml", dummySecret)).NotTo(gomega.HaveOccurred())
+	dummySecret.Namespace = utils.GetControllerNamespace()
 	g.Expect(cl.Create(context.TODO(), dummySecret)).NotTo(gomega.HaveOccurred())
 	account := &app.FybrikStorageAccount{}
 	g.Expect(readObjectFromFile("../../testdata/unittests/account-theshire.yaml", account)).NotTo(gomega.HaveOccurred())
+	account.Namespace = utils.GetControllerNamespace()
 	g.Expect(cl.Create(context.TODO(), account)).NotTo(gomega.HaveOccurred())
 
 	// Create a FybrikApplicationReconciler object with the scheme and fake client.
@@ -725,6 +754,7 @@ func TestPlotterUpdate(t *testing.T) {
 	// Read module
 	readModule := &app.FybrikModule{}
 	g.Expect(readObjectFromFile("../../testdata/unittests/module-read-parquet.yaml", readModule)).NotTo(gomega.HaveOccurred())
+	readModule.Namespace = utils.GetControllerNamespace()
 	g.Expect(cl.Create(context.Background(), readModule)).NotTo(gomega.HaveOccurred(), "the read module could not be created")
 
 	// Create a FybrikApplicationReconciler object with the scheme and fake client.
@@ -789,7 +819,9 @@ func TestSyncWithPlotter(t *testing.T) {
 	// imitate a ready phase for the earlier generation
 	application.SetGeneration(2)
 	application.Finalizers = []string{"TestReconciler.finalizer"}
-	application.Status.Generated = &app.ResourceReference{Name: "plotter", Namespace: "fybrik-system", Kind: "Plotter", AppVersion: 1}
+	controllerNamespace := utils.GetControllerNamespace()
+	fmt.Printf("FybrikApplication unit test: controller namespace " + controllerNamespace)
+	application.Status.Generated = &app.ResourceReference{Name: "plotter", Namespace: controllerNamespace, Kind: "Plotter", AppVersion: 1}
 	application.Status.Ready = true
 	application.Status.ObservedGeneration = 1
 
@@ -807,6 +839,7 @@ func TestSyncWithPlotter(t *testing.T) {
 	plotter := &app.Plotter{}
 	g.Expect(readObjectFromFile("../../testdata/plotter.yaml", plotter)).NotTo(gomega.HaveOccurred())
 	plotter.Status.ObservedState.Ready = true
+	plotter.Namespace = controllerNamespace
 	g.Expect(cl.Create(context.Background(), plotter)).NotTo(gomega.HaveOccurred())
 
 	// Create a FybrikApplicationReconciler object with the scheme and fake client.

--- a/manager/controllers/app/plotter_controller.go
+++ b/manager/controllers/app/plotter_controller.go
@@ -5,13 +5,15 @@ package app
 
 import (
 	"context"
-	"fybrik.io/fybrik/manager/controllers"
-	"fybrik.io/fybrik/pkg/environment"
 	"math"
 	"reflect"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"strings"
 	"time"
+
+	"fybrik.io/fybrik/manager/controllers"
+	"fybrik.io/fybrik/manager/controllers/utils"
+	"fybrik.io/fybrik/pkg/environment"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	"emperror.dev/errors"
 	app "fybrik.io/fybrik/manager/apis/app/v1alpha1"
@@ -129,6 +131,9 @@ func (r *PlotterReconciler) reconcile(plotter *app.Plotter) (ctrl.Result, []erro
 	// Reconciliation loop per cluster
 	isReady := true
 
+	blueprintNamespace := utils.GetBlueprintNamespace()
+	r.Log.Info("Using blueprint namespace: " + blueprintNamespace)
+
 	var errorCollection []error
 	for cluster, blueprintSpec := range plotter.Spec.Blueprints {
 		r.Log.V(1).Info("Handling spec for cluster " + cluster)
@@ -198,7 +203,7 @@ func (r *PlotterReconciler) reconcile(plotter *app.Plotter) (ctrl.Result, []erro
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        plotter.Name,
-					Namespace:   BlueprintNamespace,
+					Namespace:   blueprintNamespace,
 					ClusterName: cluster,
 					Labels: map[string]string{
 						"razee/watch-resource":        "debug",

--- a/manager/controllers/app/plotter_controller_unit_test.go
+++ b/manager/controllers/app/plotter_controller_unit_test.go
@@ -6,6 +6,8 @@ package app
 import (
 	"context"
 	"io/ioutil"
+
+	"fmt"
 	"testing"
 
 	"fybrik.io/fybrik/manager/controllers/utils"
@@ -33,9 +35,13 @@ func TestPlotterController(t *testing.T) {
 	// Set the logger to development mode for verbose logs.
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 
+	controllerNamespace := utils.GetControllerNamespace()
+	blueprintNamespace := utils.GetBlueprintNamespace()
+	fmt.Printf("Using controller namespace: %s; using blueprint namespace %s\n: "+controllerNamespace, blueprintNamespace)
+
 	var (
 		name      = "plotter"
-		namespace = "fybrik-system"
+		namespace = controllerNamespace
 	)
 
 	var err error
@@ -44,6 +50,8 @@ func TestPlotterController(t *testing.T) {
 	plotter := &app.Plotter{}
 	err = yaml.Unmarshal(plotterYAML, plotter)
 	g.Expect(err).To(gomega.BeNil(), "Cannot read plotter file for test")
+
+	plotter.Namespace = controllerNamespace
 
 	// Objects to track in the fake client.
 	objs := []runtime.Object{
@@ -87,7 +95,7 @@ func TestPlotterController(t *testing.T) {
 	g.Expect(plotter.Status.Blueprints).To(gomega.HaveKey("thegreendragon"))
 	blueprintMeta := plotter.Status.Blueprints["thegreendragon"]
 	g.Expect(blueprintMeta.Name).To(gomega.Equal(plotter.Name))
-	g.Expect(blueprintMeta.Namespace).To(gomega.Equal(BlueprintNamespace))
+	g.Expect(blueprintMeta.Namespace).To(gomega.Equal(blueprintNamespace))
 
 	// Simulate that blueprint changes state to Ready=true
 	dummyManager.DeployedBlueprints["thegreendragon"].Status.ObservedState.Ready = true

--- a/manager/controllers/motion/batchtransfer_controller_test.go
+++ b/manager/controllers/motion/batchtransfer_controller_test.go
@@ -5,6 +5,7 @@ package motion
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"time"
@@ -13,6 +14,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	motionv1 "fybrik.io/fybrik/manager/apis/motion/v1alpha1"
+	"fybrik.io/fybrik/manager/controllers/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,10 +27,13 @@ var _ = Describe("BatchTransfer Controller", func() {
 	const timeout = time.Second * 30
 	const interval = time.Millisecond * 300
 	const batchtransferName = "batchtransfer-sample"
-	const batchtransferNameSpace = "fybrik-blueprints"
 
 	BeforeEach(func() {
 		// Add any setup steps that needs to be executed before each test
+
+		batchtransferNameSpace := utils.GetBatchTransferNamespace()
+		fmt.Printf("batchtransfer namespace: %s\n ", batchtransferNameSpace)
+
 		f := &motionv1.BatchTransfer{}
 		key := client.ObjectKey{
 			Namespace: batchtransferNameSpace,
@@ -54,6 +59,10 @@ var _ = Describe("BatchTransfer Controller", func() {
 			batchTransfer := &motionv1.BatchTransfer{}
 			err = yaml.Unmarshal(batchTransferYAML, batchTransfer)
 			Expect(err).ToNot(HaveOccurred())
+
+			batchTransfer.Namespace = utils.GetBatchTransferNamespace()
+			fmt.Printf("template namespace %v\n", batchTransfer.Namespace)
+
 			registry := os.Getenv("DOCKER_HOSTNAME")
 			registryNamespace := os.Getenv("DOCKER_NAMESPACE")
 			tagName := os.Getenv("DOCKER_TAGNAME")
@@ -62,6 +71,7 @@ var _ = Describe("BatchTransfer Controller", func() {
 					batchTransfer.Spec.Image = registry + "/" + registryNamespace + "/dummy-mover:" + tagName
 				} else {
 					batchTransfer.Spec.Image = registry + "/dummy-mover:" + tagName
+
 				}
 			}
 			key := client.ObjectKeyFromObject(batchTransfer)

--- a/manager/controllers/motion/batchtransfer_controller_unit_test.go
+++ b/manager/controllers/motion/batchtransfer_controller_unit_test.go
@@ -36,9 +36,11 @@ func TestBatchTransferController(t *testing.T) {
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 	g := gomega.NewGomegaWithT(t)
 
+	batchTransferNamespace := utils.GetBatchTransferNamespace()
+
 	var (
 		name      = "sample-transfer"
-		namespace = "fybrik-system"
+		namespace = batchTransferNamespace
 	)
 	batchTransfer := &motionv1.BatchTransfer{
 		ObjectMeta: metav1.ObjectMeta{

--- a/manager/controllers/motion/motion_controllers.go
+++ b/manager/controllers/motion/motion_controllers.go
@@ -20,7 +20,6 @@ func SetupMotionControllers(mgr manager.Manager) error {
 	if err := NewBatchTransferReconciler(mgr, "BatchTransferController").SetupWithManager(mgr); err != nil {
 		return errors.Wrap(err, "unable to create BatchTransfer controller")
 	}
-
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
 		if err := (&motionv1.BatchTransfer{}).SetupWebhookWithManager(mgr); err != nil {
 			return errors.Wrap(err, "unable to create BatchTransfer webhook")

--- a/manager/controllers/motion/streamtransfer_controller_test.go
+++ b/manager/controllers/motion/streamtransfer_controller_test.go
@@ -5,16 +5,18 @@ package motion
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	motionv1 "fybrik.io/fybrik/manager/apis/motion/v1alpha1"
+	"fybrik.io/fybrik/manager/controllers/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	apps "k8s.io/api/apps/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 )
@@ -24,11 +26,14 @@ var _ = Describe("StreamTransfer Controller", func() {
 	const timeout = time.Second * 30
 	const interval = time.Millisecond * 100
 	const streamtransferName = "streamtransfer-sample"
-	const streamtransferNameSpace = "fybrik-blueprints"
 
 	BeforeEach(func() {
 		// Add any setup steps that needs to be executed before each test
 		f := &motionv1.StreamTransfer{}
+
+		streamtransferNameSpace := utils.GetStreamTransferNamespace()
+		fmt.Printf("streamtransfer namespace: %s\n", streamtransferNameSpace)
+
 		key := client.ObjectKey{
 			Namespace: streamtransferNameSpace,
 			Name:      streamtransferName,
@@ -52,6 +57,15 @@ var _ = Describe("StreamTransfer Controller", func() {
 			streamTransfer := &motionv1.StreamTransfer{}
 			err = yaml.Unmarshal(streamTransferYAML, streamTransfer)
 			Expect(err).ToNot(HaveOccurred())
+
+			streamTransfer.Namespace = utils.GetStreamTransferNamespace()
+			fmt.Printf("template namespace %v\n", streamTransfer.Namespace)
+
+			//registry := os.Getenv("DOCKER_HOSTNAME")
+			//if len(registry) > 0 {
+			//	streamTransfer.Spec.Image = registry + "/dummy-mover:latest"
+			//}
+			//fmt.Printf("%v\n", registry)
 
 			key := client.ObjectKeyFromObject(streamTransfer)
 

--- a/manager/controllers/motion/streamtransfer_controller_test.go
+++ b/manager/controllers/motion/streamtransfer_controller_test.go
@@ -61,11 +61,11 @@ var _ = Describe("StreamTransfer Controller", func() {
 			streamTransfer.Namespace = utils.GetStreamTransferNamespace()
 			fmt.Printf("template namespace %v\n", streamTransfer.Namespace)
 
-			//registry := os.Getenv("DOCKER_HOSTNAME")
-			//if len(registry) > 0 {
+			// registry := os.Getenv("DOCKER_HOSTNAME")
+			// if len(registry) > 0 {
 			//	streamTransfer.Spec.Image = registry + "/dummy-mover:latest"
-			//}
-			//fmt.Printf("%v\n", registry)
+			// }
+			// fmt.Printf("%v\n", registry)
 
 			key := client.ObjectKeyFromObject(streamTransfer)
 

--- a/manager/controllers/motion/suite_test.go
+++ b/manager/controllers/motion/suite_test.go
@@ -5,6 +5,7 @@ package motion
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 
 	motionv1 "fybrik.io/fybrik/manager/apis/motion/v1alpha1"
+	"fybrik.io/fybrik/manager/controllers/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	kbatch "k8s.io/api/batch/v1"
@@ -49,7 +51,7 @@ func TestMotionAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	RunSpecsWithDefaultAndCustomReporters(t,
-		"Controller Suite",
+		"Controller Suite App",
 		[]Reporter{printer.NewlineReporter{}})
 }
 
@@ -96,7 +98,11 @@ var _ = BeforeSuite(func(done Done) {
 		logf.Log.Info("Using existing controller in existing cluster...")
 		k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	} else {
-		workerNamespaceSelector := fields.SelectorFromSet(fields.Set{"metadata.namespace": "fybrik-blueprints"})
+		fmt.Printf("Setup fake environment... \n")
+
+		blueprintNamespace := utils.GetBlueprintNamespace()
+		fmt.Printf("Motion test suite using blueprint namespace: %s\n", blueprintNamespace)
+		workerNamespaceSelector := fields.SelectorFromSet(fields.Set{"metadata.namespace": blueprintNamespace})
 		selectorsByObject := cache.SelectorsByObject{
 			&motionv1.BatchTransfer{}:       {Field: workerNamespaceSelector},
 			&motionv1.StreamTransfer{}:      {Field: workerNamespaceSelector},
@@ -127,7 +133,7 @@ var _ = BeforeSuite(func(done Done) {
 		k8sClient = mgr.GetClient()
 		err = k8sClient.Create(context.Background(), &v1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "fybrik-blueprints",
+				Name: blueprintNamespace,
 			},
 		})
 		Expect(err).ToNot(HaveOccurred())

--- a/manager/controllers/utils/environmentVariable.go
+++ b/manager/controllers/utils/environmentVariable.go
@@ -1,3 +1,6 @@
+// Copyright 2021 IBM Corp.
+// SPDX-License-Identifier: Apache-2.0
+
 package utils
 
 import (
@@ -11,18 +14,16 @@ const DefaultBlueprintNamespace = "fybrik-blueprints"
 const DefaultControllerNamespace = "fybrik-system"
 
 func GetBlueprintNamespace() string {
-
 	blueprintNamespace := os.Getenv("BLUEPRINT_NAMESPACE")
-	if len(blueprintNamespace) <= 0 {
+	if len(blueprintNamespace) == 0 {
 		blueprintNamespace = DefaultBlueprintNamespace
 	}
 	return blueprintNamespace
 }
 
 func GetControllerNamespace() string {
-
 	controllerNamespace := os.Getenv("CONTROLLER_NAMESPACE")
-	if len(controllerNamespace) <= 0 {
+	if len(controllerNamespace) == 0 {
 		controllerNamespace = DefaultControllerNamespace
 	}
 	return controllerNamespace
@@ -30,7 +31,6 @@ func GetControllerNamespace() string {
 
 func GetApplicationNamespace() string {
 	return os.Getenv("APPLICATION_NAMESPACE")
-
 }
 
 func GetBatchTransferNamespace() string {

--- a/manager/controllers/utils/environmentVariable.go
+++ b/manager/controllers/utils/environmentVariable.go
@@ -1,0 +1,42 @@
+package utils
+
+import (
+	"os"
+)
+
+// BlueprintNamespace defines a namespace where blueprints and associated resources will be allocated
+const DefaultBlueprintNamespace = "fybrik-blueprints"
+
+// Controller namespace defines a namespace where
+const DefaultControllerNamespace = "fybrik-system"
+
+func GetBlueprintNamespace() string {
+
+	blueprintNamespace := os.Getenv("BLUEPRINT_NAMESPACE")
+	if len(blueprintNamespace) <= 0 {
+		blueprintNamespace = DefaultBlueprintNamespace
+	}
+	return blueprintNamespace
+}
+
+func GetControllerNamespace() string {
+
+	controllerNamespace := os.Getenv("CONTROLLER_NAMESPACE")
+	if len(controllerNamespace) <= 0 {
+		controllerNamespace = DefaultControllerNamespace
+	}
+	return controllerNamespace
+}
+
+func GetApplicationNamespace() string {
+	return os.Getenv("APPLICATION_NAMESPACE")
+
+}
+
+func GetBatchTransferNamespace() string {
+	return GetBlueprintNamespace()
+}
+
+func GetStreamTransferNamespace() string {
+	return GetBlueprintNamespace()
+}

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -4,19 +4,19 @@
 
 ## Bootstrapping
 
-Initial install for a cluster must happen in fybrik-system (currently).  It won't hurt anything if you aren't sure, and reinstall in fybrik-system.
-```
-. source-external.sh
-bash -x bootstrap-pipeline.sh fybrik-system
-# follow on screen instructions
-```
+Run the following command to bootstrap a Fybrik instance. By default the instance of Fybrik will be deployed as namespaced scoped, meaning the controller will only watch and process FybrikApplications from a specific namespace. Therefore limiting you to create FybrikApplications from one namespace. By default that namespace is the one specified on the bootstrap script (a.k.a *system* namespace). You can change this behavior by setting environment variables. For details see [Scoping the deployment](#scoping-the-deployment).
 
-Subsequent installs can go in any namespace
+The parameter specified is the *system* namespace. 
 ```
 . source-external.sh
 bash -x bootstrap-pipeline.sh fybrik-myname
 # follow on screen instructions
 ```
+
+After running the "tkn" command that was returned from the bootstrap script, the following namespaces will be created. Illistrated by using the example *system* namespace of fybrik-myname:
+1. fybrik-myname - This will be the *system* namespace where Fybrik is deployed. By default the controller will only process FybrikApplications from this namespace.
+2. fybrik-myname-blueprints - this is the designated namespace for blueprints custom resources. This is also where the data access module is deployed to. 
+3. fybrik-myname-app - This namespace is only created if running namespace scoped AND the following environment variable is set: use_application_namespace=true.  
 
 ## Restarting individual tasks
 
@@ -30,6 +30,25 @@ From command line, it can be done with this script:
 
 knative eventing is used to restart all downstream tasks.  Code rebuilds will trigger image rebuilds.  Image rebuilds will trigger helm upgrades.
 
+## Scoping the deployment
+In the following section the *system* namespace is the namespace specified when running the bootstrap script.
+
+By default the bootstrap script will deploy Fybrik namespaced scoped. Deploying as namespaced scoped allows multiple instances of Fybrik to be installed in unique namespaces in the same cluster.  You can change this behavior but you must do so with care.
+
+### Environment variables
+| Name  | Default  | Valid Values | Description |
+|-------|----------|--------------|-------------|
+| cluster_scoped | false | true, false | Indicates if deploy as cluster scoped meaning the controller will watch and process FybrikApplications from all namespaces. For caveats see [tips](#tips) |
+| use_application_namespace | false | true, false | Specifies if you want the bootstrap script to create a namespace for FybrikApplications. This will be ignore if cluster_scoped=true. If set to false the *system* namespace will be used. |
+
+### Tips
+1. When deploying a Fybrik instance as cluster scoped - **Disclaimer: Only use cluster scope if you know what you’re doing.**
+   1. There can only be one instance of Fybrik deployed in cluster. 
+   2. The controller will be setup so it watches all namespaces for FybrikApplications.
+   3. You cannot run namespaced scoped and cluster scoped in same cluster.
+
+2. When deploying a Fybrik instance as namespaced scoped, you can only create FybrikApplication custom resources from one namespace. The default behavior set up by the pipeline, will allow creating FybrikApplication resourcss from the *system*-app namespace. You can override this behavior by setting the use_application_namespace environment variable to false. The bootstrap code will create the *system*-app namespace and necessary objects to allow creating FybrikApplications. Hint: You will see the application namespace in the -p mesh-for-data-values= in the tkn command that is returned from running the bootstrap script.
+
 ## Building code from your development environment
 
 Set the following environment variable to point at your code repo, and it will be copied to the volume tekton tasks will mount rather than cloning code from github
@@ -37,3 +56,4 @@ Set the following environment variable to point at your code repo, and it will b
 github_workspace="/path/to/fybrik"
 . source-external.sh
 ```
+

--- a/pipeline/eventlistener/generic-image-pipeline.yaml
+++ b/pipeline/eventlistener/generic-image-pipeline.yaml
@@ -1,0 +1,67 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: print-generic
+spec:
+  params:
+    - description: IMAGE_DIGEST
+      name: IMAGE_DIGEST
+      type: string
+    - description: GENERATE_NAME
+      name: GENERATE_NAME
+      type: string
+    - name: IMAGE_NAME
+      type: string 
+    - name: IMAGE_ID
+      type: string
+    - description: Type of Event
+      name: event-type
+      type: string
+  tasks:
+    - name: print-generic
+      params:
+        - name: IMAGE_DIGEST
+          value: $(params.IMAGE_DIGEST)
+        - name: GENERATE_NAME
+          value: $(params.GENERATE_NAME)
+        - name: IMAGE_NAME
+          value: $(params.IMAGE_NAME)
+        - name: IMAGE_ID
+          value: $(params.IMAGE_ID)
+        - name: event-type
+          value: $(params.event-type)
+      taskRef:
+        kind: Task
+        name: print-generic
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: print-generic-code-update
+spec:
+  params:
+    - description: COMPONENT_NAME 
+      name: COMPONENT_NAME
+      type: string
+    - description: GENERATE_NAME
+      name: GENERATE_NAME
+      type: string
+    - description: Type of Event
+      name: event-type
+      type: string
+  tasks:
+    - name: print-generic
+      params:
+        - name: IMAGE_DIGEST
+          value: $(params.COMPONENT_NAME)
+        - name: GENERATE_NAME
+          value: $(params.GENERATE_NAME)
+        - name: IMAGE_NAME
+          value: $(params.COMPONENT_NAME)
+        - name: IMAGE_ID
+          value: $(params.COMPONENT_NAME)
+        - name: event-type
+          value: $(params.event-type)
+      taskRef:
+        kind: Task
+        name: print-generic

--- a/pipeline/eventlistener/triggerbinding.yaml
+++ b/pipeline/eventlistener/triggerbinding.yaml
@@ -12,6 +12,8 @@ spec:
       value: $(body.spec.params[?(@.name=='docker-hostname')].value)
     - name: docker-namespace
       value: $(body.spec.params[?(@.name=='docker-namespace')].value)
+    - name: blueprintNamespace
+      value: $(body.spec.params[?(@.name=='blueprintNamespace')].value)
     - name: NAMESPACE
       value: $(body.metadata.namespace)
     - name: IMAGE_ID
@@ -31,6 +33,8 @@ spec:
       value: $(body.spec.params[?(@.name=='docker-hostname')].value)
     - name: docker-namespace
       value: $(body.spec.params[?(@.name=='docker-namespace')].value)
+    - name: blueprintNamespace
+      value: $(body.spec.params[?(@.name=='blueprintNamespace')].value)
     - name: NAMESPACE
       value: $(body.metadata.namespace)
     - name: event-type

--- a/pipeline/eventlistener/triggertemplate.yaml
+++ b/pipeline/eventlistener/triggertemplate.yaml
@@ -19,6 +19,8 @@ spec:
       description: NAMESPACE
     - description: Event Type
       name: event-type
+    - description: blueprintNamespace
+      name: blueprintNamespace
   resourcetemplates:
     - apiVersion: tekton.dev/v1beta1
       kind: PipelineRun
@@ -42,6 +44,8 @@ spec:
             value: $(tt.params.NAMESPACE)
           - name: event-type
             value: $(tt.params.event-type)
+          - name: blueprintNamespace
+            value: $(tt.params.blueprintNamespace)
         workspaces:
           - name: shared-workspace
             persistentVolumeClaim:
@@ -71,6 +75,8 @@ spec:
       description: NAMESPACE
     - description: Event Type
       name: event-type
+    - description: blueprintNamespace
+      name: blueprintNamespace
   resourcetemplates:
     - apiVersion: tekton.dev/v1beta1
       kind: PipelineRun
@@ -92,6 +98,8 @@ spec:
             value: $(tt.params.event-type)
           - name: IMAGE_DIGEST
             value: none
+          - name: blueprintNamespace
+            value: $(tt.params.blueprintNamespace)
         workspaces:
           - name: shared-workspace
             persistentVolumeClaim:

--- a/pipeline/gen-git-pat-secret.sh
+++ b/pipeline/gen-git-pat-secret.sh
@@ -8,3 +8,4 @@ kubectl delete secret git-pat
 kubectl create secret generic git-pat --from-literal=username=${github_user} --from-literal=password=${pat} --type=kubernetes.io/basic-auth
 kubectl annotate secret git-pat --overwrite 'tekton.dev/git-0'="https://${github_host}"
 kubectl secrets link pipeline git-pat --for=mount
+

--- a/pipeline/gen-git-ssh-secret.sh
+++ b/pipeline/gen-git-ssh-secret.sh
@@ -7,3 +7,4 @@ kubectl delete secret git-ssh-key
 kubectl create secret generic git-ssh-key --from-file=ssh-privatekey=${ssh_key} --type=kubernetes.io/ssh-auth
 kubectl annotate secret git-ssh-key --overwrite 'tekton.dev/git-0'="${github_host}"
 kubectl secrets link pipeline git-ssh-key --for=mount
+

--- a/pipeline/pipeline.yaml
+++ b/pipeline/pipeline.yaml
@@ -10,6 +10,9 @@ spec:
   - description: namespace to deploy control plane to.  If nobody has deployed fybrik on this cluster before, choose fybrik-system.
     name: NAMESPACE
     type: string
+  - description: namespace to deploy blueprints to. Name will be derived from control plane namespace.  If control plane namespace is set to fybrik-system; this will default to fybrik-blueprints.
+    name: blueprintNamespace
+    type: string
   - default: kind-registry:5000
     description: docker registry hostname.  This is where images will be pushed once built
     name: docker-hostname
@@ -150,6 +153,8 @@ spec:
       value: fybrik/manager
     - name: image
       value: $(params.build_image)
+    - name: blueprintNamespace
+      value: "$(params.blueprintNamespace)"
     - name: docker-hostname
       value: "$(params.docker-hostname)"
     - name: docker-namespace
@@ -191,6 +196,8 @@ spec:
       value: "$(params.docker-hostname)"
     - name: docker-namespace
       value: "$(params.docker-namespace)"
+    - name: blueprintNamespace
+      value: "$(params.blueprintNamespace)"
     runAfter:
     - build-manager
     taskRef:
@@ -251,6 +258,8 @@ spec:
       value: "$(params.docker-hostname)"
     - name: docker-namespace
       value: "$(params.docker-namespace)"
+    - name: blueprintNamespace
+      value: "$(params.blueprintNamespace)"
     runAfter:
     - fetch-repository
     taskRef:
@@ -307,6 +316,8 @@ spec:
       value: "$(params.docker-hostname)"
     - name: docker-namespace
       value: "$(params.docker-namespace)"
+    - name: blueprintNamespace
+      value: "$(params.blueprintNamespace)"
     - name: INCREMENTAL_CODE_RESTART
       value: $(params.INCREMENTAL_CODE_RESTART)
     runAfter:
@@ -344,6 +355,8 @@ spec:
       value: "$(params.docker-hostname)"
     - name: docker-namespace
       value: "$(params.docker-namespace)"
+    - name: blueprintNamespace
+      value: "$(params.blueprintNamespace)"
     runAfter:
     - build-katalog
     taskRef:
@@ -400,6 +413,8 @@ spec:
       value: "$(params.docker-hostname)"
     - name: docker-namespace
       value: "$(params.docker-namespace)"
+    - name: blueprintNamespace
+      value: $(params.blueprintNamespace)
     - name: INCREMENTAL_CODE_RESTART
       value: $(params.INCREMENTAL_CODE_RESTART)
     runAfter:
@@ -437,6 +452,8 @@ spec:
       value: "$(params.docker-hostname)"
     - name: docker-namespace
       value: "$(params.docker-namespace)"
+    - name: blueprintNamespace
+      value: "$(params.blueprintNamespace)"
     runAfter:
     - build-opa
     taskRef:
@@ -493,6 +510,8 @@ spec:
       value: "$(params.docker-hostname)"
     - name: docker-namespace
       value: "$(params.docker-namespace)"
+    - name: blueprintNamespace
+      value: "$(params.blueprintNamespace)"
     - name: INCREMENTAL_CODE_RESTART
       value: $(params.INCREMENTAL_CODE_RESTART)
     runAfter:
@@ -530,6 +549,8 @@ spec:
       value: "$(params.docker-hostname)"
     - name: docker-namespace
       value: "$(params.docker-namespace)"
+    - name: blueprintNamespace
+      value: "$(params.blueprintNamespace)"
     runAfter:
     - build-datacatalog
     taskRef:
@@ -586,6 +607,8 @@ spec:
       value: "$(params.docker-hostname)"
     - name: docker-namespace
       value: "$(params.docker-namespace)"
+    - name: blueprintNamespace
+      value: "$(params.blueprintNamespace)"
     - name: INCREMENTAL_CODE_RESTART
       value: $(params.INCREMENTAL_CODE_RESTART)
     runAfter:
@@ -623,6 +646,8 @@ spec:
       value: "$(params.docker-hostname)"
     - name: docker-namespace
       value: "$(params.docker-namespace)"
+    - name: blueprintNamespace
+      value: "$(params.blueprintNamespace)"
     runAfter:
     - build-servicepolicymanager
     taskRef:
@@ -676,7 +701,7 @@ spec:
     - name: release_namespace
       value: $(params.NAMESPACE)
     - name: overwrite_values
-      value: clusterScoped=$(params.clusterScoped),global.hub=$(params.docker-hostname)/$(params.docker-namespace),global.tag="",manager.image=$(params.docker-hostname)/$(params.docker-namespace)/$(params.MANAGER_IMAGE)@$(tasks.build-image-manager.results.IMAGE_DIGEST),katalogConnector.image=$(params.docker-hostname)/$(params.docker-namespace)/$(params.KATALOG_IMAGE)@$(tasks.build-image-katalog.results.IMAGE_DIGEST),opaConnector.image=$(params.docker-hostname)/$(params.docker-namespace)/opa-connector@$(tasks.build-image-opa.results.IMAGE_DIGEST),cluster.name=$(params.NAMESPACE),coordinator.vault.address=http://vault.fybrik-system:8200,vault.address=http://vault.fybrik-system:8200,$(params.fybrik-values)
+      value: blueprintNamespace=$(params.blueprintNamespace),clusterScoped=$(params.clusterScoped),global.hub=$(params.docker-hostname)/$(params.docker-namespace),global.tag="",manager.image=$(params.docker-hostname)/$(params.docker-namespace)/$(params.MANAGER_IMAGE)@$(tasks.build-image-manager.results.IMAGE_DIGEST),katalogConnector.image=$(params.docker-hostname)/$(params.docker-namespace)/$(params.KATALOG_IMAGE)@$(tasks.build-image-katalog.results.IMAGE_DIGEST),opaConnector.image=$(params.docker-hostname)/$(params.docker-namespace)/opa-connector@$(tasks.build-image-opa.results.IMAGE_DIGEST),cluster.name=$(params.NAMESPACE),coordinator.vault.address=http://$(params.NAMESPACE)-vault.$(params.NAMESPACE):8200,vault.address=http://$(params.NAMESPACE)-vault.$(params.NAMESPACE):8200,$(params.fybrik-values)
     - name: release_version
       value: 0.1.0
     - name: image
@@ -849,6 +874,7 @@ spec:
       Operator: notin
       Values:
       - "true"
+      
   - name: run-integration-tests-full-deploy
     params:
     - name: target
@@ -858,7 +884,7 @@ spec:
     - name: image
       value: $(params.build_image)
     - name: flags
-      value: DOCKER_HOSTNAME=$(params.docker-hostname) DOCKER_NAMESPACE=$(params.docker-namespace) USE_MOCKUP_CONNECTOR=false
+      value: DOCKER_HOSTNAME=$(params.docker-hostname) DOCKER_NAMESPACE=$(params.docker-namespace) USE_MOCKUP_CONNECTOR=false CONTROLLER_NAMESPACE=$(params.NAMESPACE) BLUEPRINT_NAMESPACE=$(params.blueprintNamespace)
     - name: INCREMENTAL_CODE_RESTART
       value: $(params.INCREMENTAL_CODE_RESTART)
     runAfter:
@@ -885,7 +911,7 @@ spec:
     - name: image
       value: $(params.build_image)
     - name: flags
-      value: DOCKER_HOSTNAME=$(params.docker-hostname) DOCKER_NAMESPACE=$(params.docker-namespace) USE_MOCKUP_CONNECTOR=false
+      value: DOCKER_HOSTNAME=$(params.docker-hostname) DOCKER_NAMESPACE=$(params.docker-namespace) USE_MOCKUP_CONNECTOR=false CONTROLLER_NAMESPACE=$(params.NAMESPACE) BLUEPRINT_NAMESPACE=$(params.blueprintNamespace)
     runAfter:
     - upgrade-helm-partial
     when:
@@ -909,6 +935,8 @@ spec:
       value: $(params.build_image)
     - name: INCREMENTAL_CODE_RESTART
       value: $(params.INCREMENTAL_CODE_RESTART)
+    - name: flags
+      value: CONTROLLER_NAMESPACE=$(params.NAMESPACE) BLUEPRINT_NAMESPACE=$(params.blueprintNamespace)
     runAfter:
     - upgrade-helm-full
     when:
@@ -928,6 +956,8 @@ spec:
       value: test
     - name: context
       value: fybrik
+    - name: flags
+      value: CONTROLLER_NAMESPACE=$(params.NAMESPACE) BLUEPRINT_NAMESPACE=$(params.blueprintNamespace) 
     - name: image
       value: $(params.build_image)
     runAfter:

--- a/pipeline/source-external.sh
+++ b/pipeline/source-external.sh
@@ -12,6 +12,9 @@ export image_repo="${image_repo:-kind-registry:5000}"
 export image_source_repo="${image_source_repo:-fake.com}"
 export dockerhub_hostname="${dockerhub_hostname:-docker.io}"
 export git_url="https://github.com/fybrik/fybrik.git"
+export cluster_scoped=false
+export use_application_namespace=true
+
 echo "
 ## Git credentials
 For authenticated registries, if you use a git token instead of ssh key, credentials will not be deleted when the run is complete (and therefore, you will not have to regenerate them when restarting tasks).

--- a/pipeline/tasks/buildah.yaml
+++ b/pipeline/tasks/buildah.yaml
@@ -56,6 +56,9 @@ spec:
   - default: ""
     name: docker-namespace
     type: string
+  - default: ""
+    name: blueprintNamespace
+    type: string
   results:
   - description: Digest of the image just built.
     name: IMAGE_DIGEST

--- a/pipeline/tasks/git-clone.yaml
+++ b/pipeline/tasks/git-clone.yaml
@@ -71,7 +71,6 @@ spec:
     name: url
   steps:
   - image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.21.0
-#registry.redhat.io/openshift-pipelines-tech-preview/pipelines-git-init-rhel8@sha256:7e18e13a94c9c82e369274984500401e27684d3565393cf6ed2bad55f2d751bc
     name: clone
     resources: {}
     script: |

--- a/pipeline/tasks/shell.yaml
+++ b/pipeline/tasks/shell.yaml
@@ -1,29 +1,20 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: make
+  name: shell
 spec:
   description: This Task is Golang task to test Go projects.
   params:
-  - default: ""
-    description: 'packages to test (default: ./...)'
-    name: packages
-    type: string
   - default: .
     description: path to the directory to use as context.
     name: context
     type: string
+  - description: path to the directory to use as context.
+    name: command
+    type: string
   - default: latest
     description: golang version to use for tests
     name: version
-    type: string
-  - default: ""
-    description: flags to use for the test command
-    name: flags
-    type: string
-  - default: ""
-    description: make target
-    name: target
     type: string
   - default: ""
     description: env vars for make command
@@ -49,7 +40,7 @@ spec:
     description: Go mod caching directory path
     name: GOMODCACHE
     type: string
-  - default: "docker.io/yakinikku/suede_compile:latest"
+  - default: "docker.io/yakinikku/suede:latest"
     description: default image to use for compiling
     name: image
     type: string
@@ -93,7 +84,7 @@ spec:
       env
       pwd
       cd $(params.context)
-      $(params.env_vars) make $(params.target) $(params.flags) $(params.packages)
+      $(params.env_vars) $(params.command)
     workingDir: $(workspaces.source.path)
   - image: $(params.image)
     name: docker-namespace-to-results


### PR DESCRIPTION
* Pipeline (#1)

* add new source-build options for multi stage build

* allow override of registries to avoid dockerhub rate limit

* update tests to allow for override of docker hostname when building in non-kind cluster

* remove docker ignore file, buildah and other container build tools don't like this format

* add step to ensure csv for openshift-pipelines installed on OpenShift, or tekton-pipelines is installed on kube

* add support for knative based restarting of pipeline

* add onepipeline file for security scanning

* add secrets baseline file

https://w3.ibm.com/w3publisher/detect-secrets/developer-tool

* make integration tests work

performs additional cleanup for subsequent runs
blocks m4dapplication test from running when wkc connector is configured
  - need to adjust this such that it is configurable from pipeline

* use fybrik-system until multi-tenancy is supported

* Support tekton install via Kind with basic nfs install

* cleanup for upstream effort

Co-authored-by: Nicholas Goracke <ngoracke@us.ibm.com>
Co-authored-by: Jonathan L Kaus <jlkaus@us.ibm.com>
Signed-off-by: Nicholas Goracke <ngoracke@us.ibm.com>

* address comment on fybrik-system vs m4d-system

Signed-off-by: Nicholas Goracke <ngoracke@us.ibm.com>

* address review comments

Remove source-internal
Remove values not relevant to non-wkc-controller pipeline
Remove wkc pipeline
Set default for WKC controller to false

Signed-off-by: Nicholas Goracke <ngoracke@us.ibm.com>

* Address review comments regarding WKC appearance

This will allow the existing test to run in the standard kind deployment, but allow those using other
connectors to disable the test

Signed-off-by: Nicholas Goracke <ngoracke@us.ibm.com>

* only set git urls for the pipeline it is relevant for

Signed-off-by: Nicholas Goracke <ngoracke@us.ibm.com>

* remove .secrets.baseline temporarily per review comments

Signed-off-by: Nicholas Goracke <ngoracke@us.ibm.com>

* remove references to ibm url

Signed-off-by: Nicholas Goracke <ngoracke@us.ibm.com>

* ensure failure if pipelinerun doesn't complete for ci, mesh-for-data to fybrik

Signed-off-by: Nicholas Goracke <ngoracke@us.ibm.com>

* address comment on desired condition for unset var

Signed-off-by: Nicholas Goracke <ngoracke@us.ibm.com>

* restart GitHub Actions

Signed-off-by: Nicholas Goracke <ngoracke@us.ibm.com>

* Merge pull request #1 from IBM-Data-Fabric/namespaced

Add support for configuring the blueprint namespace and allow deploying multiple instances of Fybrik to different namespaces in the same cluster.

Signed-off-by: laurieaw <laurieaw@us.ibm.com>

* remove excess quotes

Signed-off-by: laurieaw <laurieaw@us.ibm.com>

* Update README.md

Signed-off-by: laurieaw <laurieaw@us.ibm.com>

* Add disclaimer to the Readme

Signed-off-by: laurieaw <laurieaw@us.ibm.com>

* change image in shell script

* change image in shell script

Signed-off-by: laurieaw <laurieaw@us.ibm.com>

* Remove namespace name from metadata.name

* Fix conflict in source external

* Resolve conflicts in bootstrap script

* fix typo in blueprintNamespace

* determine whether or not comma should be appended

* set defaults for namespaces on unit tests

* Updates from review comments

Co-authored-by: ngoracke <yakinikku@gmail.com>
Co-authored-by: Nicholas Goracke <ngoracke@us.ibm.com>
Co-authored-by: Jonathan L Kaus <jlkaus@us.ibm.com>