### PR TITLE
Fix to fybrik_notebook_test.go 

### DIFF
--- a/manager/controllers/app/fybrik_notebook_test.go
+++ b/manager/controllers/app/fybrik_notebook_test.go
@@ -7,7 +7,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
+	"net"
+	"os"
+	"strings"
+	"testing"
+
 	apiv1alpha1 "fybrik.io/fybrik/manager/apis/app/v1alpha1"
+	"fybrik.io/fybrik/pkg/test"
 	"github.com/apache/arrow/go/arrow"
 	"github.com/apache/arrow/go/arrow/array"
 	"github.com/apache/arrow/go/arrow/flight"
@@ -21,15 +28,8 @@ import (
 	"google.golang.org/grpc"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
-	"log"
-	"net"
-	"os"
-	"os/exec"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strconv"
-	"strings"
-	"testing"
 )
 
 type ArrowRequest struct {
@@ -149,15 +149,14 @@ func TestS3Notebook(t *testing.T) {
 	svcName := strings.Replace(application.Status.AssetStates["fybrik-notebook-sample/data-csv"].Endpoint.Hostname, ".fybrik-blueprints.svc.cluster.local", "", 1)
 	port := application.Status.AssetStates["fybrik-notebook-sample/data-csv"].Endpoint.Port
 
-	command := exec.Command("kubectl", "-n", BlueprintNamespace, "port-forward", "svc/"+svcName, "8083:"+strconv.Itoa(int(port)))
-	err = command.Start()
 	By("Starting kubectl port-forward for arrow-flight")
+	listenPort, err := test.RunPortForward(BlueprintNamespace, svcName, int(port))
 	Expect(err).To(BeNil())
 
 	// Reading data via arrow flight
 	opts := make([]grpc.DialOption, 0)
 	opts = append(opts, grpc.WithInsecure())
-	flightClient, err := flight.NewFlightClient(net.JoinHostPort("localhost", "8083"), nil, opts...)
+	flightClient, err := flight.NewFlightClient(net.JoinHostPort("localhost", listenPort), nil, opts...)
 	Expect(err).To(BeNil(), "Connect to arrow-flight service")
 	defer flightClient.Close()
 
@@ -172,7 +171,6 @@ func TestS3Notebook(t *testing.T) {
 		Type: flight.FlightDescriptor_CMD,
 		Cmd:  marshal,
 	})
-	// TODO Flight server access is currently not working
 	Expect(err).To(BeNil())
 
 	stream, err := flightClient.DoGet(context.Background(), info.Endpoint[0].Ticket)

--- a/pkg/test/portforward.go
+++ b/pkg/test/portforward.go
@@ -34,6 +34,8 @@ func StartCmdAndStreamOutput(cmd *exec.Cmd) (stdout, stderr io.ReadCloser, err e
 // runPortForward runs port-forward, warning, this may need root functionality on some systems.
 // The function was inspired from kubernetes e2e framework
 func RunPortForward(ns string, svcName string, port int) (string, error) {
+	/* #nosec G204 */
+	// Avoid "Subprocess launched with variable" error
 	cmd := exec.Command("kubectl", "-n", ns, "port-forward", "svc/"+svcName, ":"+strconv.Itoa(port))
 	// This is somewhat ugly but is the only way to retrieve the port that was picked
 	// by the port-forward command. We don't want to hard code the port as we have no

--- a/pkg/test/portforward.go
+++ b/pkg/test/portforward.go
@@ -1,0 +1,63 @@
+// Copyright 2020 IBM Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+package test
+
+import (
+	"io"
+	"os/exec"
+	"regexp"
+	"strconv"
+)
+
+// TODO support other ports besides 80
+var (
+	portForwardRegexp = regexp.MustCompile(`Forwarding from (127.0.0.1|\\[::1\\]):([0-9]+) -> 80`)
+)
+
+// StartCmdAndStreamOutput returns stdout and stderr after starting the given cmd.
+// The function was inspired from kubernetes e2e framework
+func StartCmdAndStreamOutput(cmd *exec.Cmd) (stdout, stderr io.ReadCloser, err error) {
+	stdout, err = cmd.StdoutPipe()
+	if err != nil {
+		return
+	}
+	stderr, err = cmd.StderrPipe()
+	if err != nil {
+		return
+	}
+
+	err = cmd.Start()
+	return
+}
+
+// runPortForward runs port-forward, warning, this may need root functionality on some systems.
+// The function was inspired from kubernetes e2e framework
+func RunPortForward(ns string, svcName string, port int) (string, error) {
+	cmd := exec.Command("kubectl", "-n", ns, "port-forward", "svc/"+svcName, ":"+strconv.Itoa(port))
+	// This is somewhat ugly but is the only way to retrieve the port that was picked
+	// by the port-forward command. We don't want to hard code the port as we have no
+	// way of guaranteeing we can pick one that isn't in use, particularly on Jenkins.
+	portOutput, _, err := StartCmdAndStreamOutput(cmd)
+	if err != nil {
+		return "", err
+	}
+
+	buf := make([]byte, 128)
+	var n int
+	if n, err = portOutput.Read(buf); err != nil {
+		return "", err
+	}
+	portForwardOutput := string(buf[:n])
+	match := portForwardRegexp.FindStringSubmatch(portForwardOutput)
+	if len(match) != 3 {
+		return "", err
+	}
+
+	_, err = strconv.Atoi(match[2])
+	if err != nil {
+		return "", err
+	}
+
+	return match[2], nil
+}


### PR DESCRIPTION
This PR fixes arrow-flight server port-forwarding to make fybrik_notebook_test.go work