### PR TITLE
Fix blueprintNamespace field indentation in charts/vault/values.yaml

### DIFF
--- a/charts/vault/values.yaml
+++ b/charts/vault/values.yaml
@@ -9,4 +9,4 @@ plugins:
     namespaces: 
       #- fybrik-notebook-sample
       #- fybrik-system
-  blueprintNamespace: "fybrik-blueprints"    
+blueprintNamespace: "fybrik-blueprints"


### PR DESCRIPTION
Signed-off-by: Revital Sur <eres@il.ibm.com>