### PR TITLE
Use Role in katalog RBAC if clusterScoped=false

### DIFF
--- a/charts/fybrik/templates/fybrik-applications-rb.yaml
+++ b/charts/fybrik/templates/fybrik-applications-rb.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.manager.enabled }}
+{{- if .Values.applicationNamespace}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "fybrik.fullname" . }}-applications-rb
+  namespace: {{ .Values.applicationNamespace }}
+  labels:
+    {{- include "fybrik.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "fybrik.fullname" . }}-applications-role
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.manager.serviceAccount.name | default "default" }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/charts/fybrik/templates/fybrik-applications-role.yaml
+++ b/charts/fybrik/templates/fybrik-applications-role.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.manager.enabled }}
+{{- if .Values.applicationNamespace}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "fybrik.fullname" . }}-applications-role
+  namespace: {{ .Values.applicationNamespace }}
+rules:
+- apiGroups:
+  - app.fybrik.io
+  resources:
+  - fybrikapplications
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - app.fybrik.io
+  resources:
+  - fybrikapplications/status
+  verbs:
+  - get
+  - patch
+  - update
+{{- end }}
+{{- end }}

--- a/charts/fybrik/templates/katalog-connector/katalog-connector-rbac.yaml
+++ b/charts/fybrik/templates/katalog-connector/katalog-connector-rbac.yaml
@@ -5,18 +5,18 @@ apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.clusterScoped }}
 kind: ClusterRoleBinding
 metadata:
-  name:  katalog-connector-editor
+  name:  katalog-connector-viewer
 roleRef:
   kind: ClusterRole
 {{- else }}
 kind: RoleBinding
 metadata:
-  name:  katalog-connector-editor
+  name:  katalog-connector-viewer
   namespace: {{ .Values.applicationNamespace | default .Release.Namespace  }}
 roleRef:
   kind: Role
 {{- end }}
-  name: katalog-editor
+  name: katalog-viewer
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount

--- a/charts/fybrik/templates/katalog-connector/katalog-connector-rbac.yaml
+++ b/charts/fybrik/templates/katalog-connector/katalog-connector-rbac.yaml
@@ -1,18 +1,24 @@
 {{- $autoFlag := and .Values.coordinator.enabled (eq .Values.coordinator.catalog "katalog") }}
 {{- if include "fybrik.isEnabled" (tuple .Values.katalogConnector.enabled $autoFlag) }}
-{{- if .Values.clusterScoped }}
 # Grant katalog-connector the katalog-editor Role.
+{{- if .Values.clusterScoped }}
 kind: ClusterRoleBinding
+{{- else }}
+kind: RoleBinding
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name:  katalog-connector-editor
 roleRef:
+{{- if .Values.clusterScoped }}
   kind: ClusterRole
+{{- else }}
+  kind: Role
+{{- end }}
   name: katalog-editor
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.katalogConnector.serviceAccount.name | default "default" }}
   namespace: {{ .Release.Namespace }}
-{{- end }}
 {{- end }}

--- a/charts/fybrik/templates/katalog-connector/katalog-connector-rbac.yaml
+++ b/charts/fybrik/templates/katalog-connector/katalog-connector-rbac.yaml
@@ -1,18 +1,19 @@
 {{- $autoFlag := and .Values.coordinator.enabled (eq .Values.coordinator.catalog "katalog") }}
 {{- if include "fybrik.isEnabled" (tuple .Values.katalogConnector.enabled $autoFlag) }}
 # Grant katalog-connector the katalog-editor Role.
+apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.clusterScoped }}
 kind: ClusterRoleBinding
-{{- else }}
-kind: RoleBinding
-{{- end }}
-apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name:  katalog-connector-editor
 roleRef:
-{{- if .Values.clusterScoped }}
   kind: ClusterRole
 {{- else }}
+kind: RoleBinding
+metadata:
+  name:  katalog-connector-editor
+  namespace: {{ .Values.applicationNamespace | default .Release.Namespace  }}
+roleRef:
   kind: Role
 {{- end }}
   name: katalog-editor

--- a/charts/fybrik/templates/katalog-connector/katalog-editor-role.yaml
+++ b/charts/fybrik/templates/katalog-connector/katalog-editor-role.yaml
@@ -1,14 +1,17 @@
 {{- $autoFlag := and .Values.coordinator.enabled (eq .Values.coordinator.catalog "katalog") }}
 {{- if include "fybrik.isEnabled" (tuple .Values.katalogConnector.enabled $autoFlag) }}
 # katalog-editor allows managing assets.
+apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.clusterScoped }}
 kind: ClusterRole
-{{- else }}
-kind: Role
-{{- end }}
-apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: katalog-editor
+{{- else }}
+kind: Role
+metadata:
+  name: katalog-editor
+  namespace: {{ .Values.applicationNamespace | default .Release.Namespace  }}
+{{- end }}
 rules:
 - apiGroups: ["katalog.fybrik.io"]
   resources: ["assets"]
@@ -16,19 +19,4 @@ rules:
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]
----
-# katalog-viewer allows viewing assets.
-{{- if .Values.clusterScoped }}
-kind: ClusterRole
-{{- else }}
-kind: Role
-{{- end }}
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: katalog-viewer
-rules:
-- apiGroups: ["katalog.fybrik.io"]
-  resources: ["assets"]
-  verbs: ["get", "list", "watch"]
----
 {{- end }}

--- a/charts/fybrik/templates/katalog-connector/katalog-rbac.yaml
+++ b/charts/fybrik/templates/katalog-connector/katalog-rbac.yaml
@@ -1,8 +1,11 @@
 {{- $autoFlag := and .Values.coordinator.enabled (eq .Values.coordinator.catalog "katalog") }}
 {{- if include "fybrik.isEnabled" (tuple .Values.katalogConnector.enabled $autoFlag) }}
+# katalog-editor allows managing assets.
 {{- if .Values.clusterScoped }}
-# ClusterRole katalog-editor allows managing assets.
 kind: ClusterRole
+{{- else }}
+kind: Role
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: katalog-editor
@@ -14,8 +17,12 @@ rules:
   resources: ["secrets"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]
 ---
-# ClusterRole katalog-viewer allows viewing assets.
+# katalog-viewer allows viewing assets.
+{{- if .Values.clusterScoped }}
 kind: ClusterRole
+{{- else }}
+kind: Role
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: katalog-viewer
@@ -24,5 +31,4 @@ rules:
   resources: ["assets"]
   verbs: ["get", "list", "watch"]
 ---
-{{- end }}
 {{- end }}

--- a/charts/fybrik/templates/katalog-connector/katalog-viewer-role.yaml
+++ b/charts/fybrik/templates/katalog-connector/katalog-viewer-role.yaml
@@ -1,0 +1,19 @@
+{{- $autoFlag := and .Values.coordinator.enabled (eq .Values.coordinator.catalog "katalog") }}
+{{- if include "fybrik.isEnabled" (tuple .Values.katalogConnector.enabled $autoFlag) }}
+# katalog-viewer allows viewing assets.
+apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.clusterScoped }}
+kind: ClusterRole
+metadata:
+  name: katalog-viewer
+{{- else }}
+kind: Role
+metadata:
+  name: katalog-viewer
+  namespace: {{ .Values.applicationNamespace | default .Release.Namespace  }}
+{{- end }}
+rules:
+- apiGroups: ["katalog.fybrik.io"]
+  resources: ["assets"]
+  verbs: ["get", "list", "watch"]
+{{- end }}

--- a/charts/fybrik/values.yaml
+++ b/charts/fybrik/values.yaml
@@ -16,7 +16,8 @@ clusterScoped: true
 blueprintNamespace: "fybrik-blueprints"
 
 # Set if need to only watch for FybrikApplication from a specific namespace
-#applicationNamespace: ""
+# The namespace must already exist
+applicationNamespace: ""
 
 # Taxonomy file for taxonomy ConfigMap
 taxonomyOverride: ""

--- a/pipeline/bootstrap-pipeline.sh
+++ b/pipeline/bootstrap-pipeline.sh
@@ -198,40 +198,6 @@ if [[ ${cluster_scoped} == "false" && ${use_application_namespace} == "true"  ]]
     fi
   fi
 
-  cat > ${TMP}/approle.yaml <<EOH
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: ${unique_prefix}-app-role
-  namespace: ${unique_prefix}-app 
-rules:
-- apiGroups:
-  - '*'
-  resources:
-  - '*'
-  verbs:
-  - '*'
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: ${unique_prefix}-app-rb
-  namespace: ${unique_prefix}-app
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: ${unique_prefix}-app-role
-subjects:
-- kind: ServiceAccount
-  name: manager
-  namespace: ${unique_prefix}
-EOH
-  set +e
-  kubectl delete -f ${TMP}/approle.yaml
-  set -e
-  kubectl apply -f ${TMP}/approle.yaml
-fi
-
 set +e
 # Be smarter about this - just a quick hack for typical default OpenShift & Kind installs so we can control the default storage class
 kubectl patch storageclass managed-nfs-storage -p '{"metadata": {"annotations": {"storageclass.kubernetes.io/is-default-class": "true"}}}'

--- a/pipeline/bootstrap-pipeline.sh
+++ b/pipeline/bootstrap-pipeline.sh
@@ -197,6 +197,7 @@ if [[ ${cluster_scoped} == "false" && ${use_application_namespace} == "true"  ]]
       kubectl create ns ${unique_prefix}-app 
     fi
   fi
+fi
 
 set +e
 # Be smarter about this - just a quick hack for typical default OpenShift & Kind installs so we can control the default storage class


### PR DESCRIPTION
**Changes in this PR:**

1. Katalog RBAC is using Role/RoleBinding when clusterScoped=false. Those RBAC resources are applied to the application namespace (or if unset, to the system namespace). 
2. The RBAC for manager access to FybrikApplication resources in the application namespace is also created with the chart. Previously a `*` role was applied in the pipeline boostrap script (cc @laurieaw63)

**Why:** 

We missed adjusting the permissions of katalog. This PR changes the katalog RBAC to be scoped to the application namespace when  installed with `--set clusterScoped=false`. For consistency all RBAC resources that should be applied to the applications namespace is now set from the chart itself.


**Usage:**

After this PR the following is required for a working control plane when using `clusterScoped=false` and `applicationNamespace=fybrik-applications`:

```bash
kubectl create ns fybrik-system
kubectl create ns fybrik-blueprints
kubectl create ns fybrik-applications
helm install fybrik-crd charts/fybrik-crd
helm install fybrik charts/fybrik --namespace fybrik-system --set clusterScoped=false --set applicationNamespace=fybrik-applications --set global.tag=master --set global.imagePullPolicy=Always
```

For proper support we need the installation and code to support multi-tenancy. A discussion/issue will be opened separately. 