### PR TITLE
Add new opa connector to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,8 @@ DOCKER_PUBLIC_NAMES := \
 	dummy-mover \
 	egr-connector \
 	katalog-connector \
-	opa-connector 
+	opa-connector \
+	openpolicyagent-connector
 
 define do-docker-retag-and-push-public
 	for name in ${DOCKER_PUBLIC_NAMES}; do \


### PR DESCRIPTION
This PR adds the docker name of the V2 opa connector to the fybrik build makefile. 

Signed-off-by: Rohith D Vallam <rovallam@in.ibm.com>