### PR TITLE
use ubi as the base image for manager

### DIFF
--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -1,9 +1,10 @@
 # Copyright 2020 IBM Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM gcr.io/distroless/static:nonroot
-WORKDIR /
-COPY manager .
-USER nonroot:nonroot
+FROM ubi8/ubi-minimal
+ENV HOME=/tmp
+WORKDIR /tmp
+COPY manager /
+USER 1001
 
 ENTRYPOINT ["/manager"]

--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2020 IBM Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 ENV HOME=/tmp
 WORKDIR /tmp
 COPY manager /


### PR DESCRIPTION
Signed-off-by: Nicholas Goracke <ngoracke@us.ibm.com>