### PR TITLE
Remove PluginMechanism from fybrikmodule_types.go

### DIFF
--- a/manager/apis/app/v1alpha1/fybrikmodule_types.go
+++ b/manager/apis/app/v1alpha1/fybrikmodule_types.go
@@ -109,16 +109,12 @@ type ModuleAPI struct {
 	Endpoint EndpointSpec `json:"endpoint"`
 }
 
-// PluginMechanism indicates indicates the technology used for the module and the plugin to interact
-// The values supported should come from the module taxonomy
-// Ex: vault, wasm....
-type PluginMechanism string
-
 type Plugin struct {
 	// PluginType indicates the technology used for the module and the plugin to interact
+	// The values supported should come from the module taxonomy
 	// Examples of such mechanisms are vault plugins, wasm, etc
 	// +required
-	PluginType PluginMechanism `json:"pluginType"`
+	PluginType string `json:"pluginType"`
 
 	// DataFormat indicates the format of data the plugin knows how to process
 	DataFormat string `json:"dataFormat"`


### PR DESCRIPTION
Signed-off-by: Revital Sur <eres@il.ibm.com>
Co-authored-by: Shlomit Koyfman <shlomitk@il.ibm.com>

Its actually a `string` value and can be removed for consistency.