### PR TITLE
Remove hardcoding of blueprint namespace (#829)

### DIFF
--- a/manager/controllers/app/fybrik_notebook_test.go
+++ b/manager/controllers/app/fybrik_notebook_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	apiv1alpha1 "fybrik.io/fybrik/manager/apis/app/v1alpha1"
+	"fybrik.io/fybrik/manager/controllers/utils"
 	"fybrik.io/fybrik/pkg/test"
 	"github.com/apache/arrow/go/arrow"
 	"github.com/apache/arrow/go/arrow/array"
@@ -145,12 +146,15 @@ func TestS3Notebook(t *testing.T) {
 		return application.Status.Ready
 	}, timeout, interval).Should(Equal(true))
 
+	blueprintNamespace := utils.GetBlueprintNamespace()
+	fmt.Printf("blueprint namespace notebook test: %s\n", blueprintNamespace)
+
 	// Forward port of arrow flight service to local port
-	svcName := strings.Replace(application.Status.AssetStates["fybrik-notebook-sample/data-csv"].Endpoint.Hostname, ".fybrik-blueprints.svc.cluster.local", "", 1)
+	svcName := strings.Replace(application.Status.AssetStates["fybrik-notebook-sample/data-csv"].Endpoint.Hostname, "."+blueprintNamespace+".svc.cluster.local", "", 1)
 	port := application.Status.AssetStates["fybrik-notebook-sample/data-csv"].Endpoint.Port
 
 	By("Starting kubectl port-forward for arrow-flight")
-	listenPort, err := test.RunPortForward(BlueprintNamespace, svcName, int(port))
+	listenPort, err := test.RunPortForward(blueprintNamespace, svcName, int(port))
 	Expect(err).To(BeNil())
 
 	// Reading data via arrow flight

--- a/manager/controllers/app/moduleinstance.go
+++ b/manager/controllers/app/moduleinstance.go
@@ -443,7 +443,8 @@ func moduleAPIToService(api *app.ModuleAPI, scope app.CapabilityScope, appContex
 		releaseName := utils.GetReleaseName(appContext.Name, appContext.Namespace, instanceName)
 		// Current implementation assumes there is only one cluster with read modules
 		// (which is the same cluster the user's workload)
-		fqdn := utils.GenerateModuleEndpointFQDN(releaseName, BlueprintNamespace)
+		blueprintNamespace := utils.GetBlueprintNamespace()
+		fqdn := utils.GenerateModuleEndpointFQDN(releaseName, blueprintNamespace)
 		endpoint = app.EndpointSpec{
 			Hostname: fqdn,
 			Port:     api.Endpoint.Port,

--- a/manager/controllers/app/plotter_controller.go
+++ b/manager/controllers/app/plotter_controller.go
@@ -38,9 +38,6 @@ type PlotterReconciler struct {
 	ClusterManager multicluster.ClusterManager
 }
 
-// BlueprintNamespace defines a namespace where blueprints and associated resources will be allocated
-const BlueprintNamespace = "fybrik-blueprints"
-
 // Reconcile receives a Plotter CRD
 //nolint:dupl
 func (r *PlotterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
This is a fix for https://github.com/fybrik/fybrik/issues/829