### PR TITLE
Added a cleanup step to the notebook sample

### DIFF
--- a/site/docs/samples/notebook.md
+++ b/site/docs/samples/notebook.md
@@ -280,3 +280,7 @@ When you’re finished experimenting with the notebook sample, clean it up:
     ```bash
     kubectl delete namespace fybrik-notebook-sample
     ```
+1. Delete the policy created on fybrik-system namespace:
+    ```bash
+    kubectl -n fybrik-system delete configmap sample-policy
+    ```


### PR DESCRIPTION
Added step 3 on cleanup which deletes configmap on fybrik-system namespace.

Signed-off-by: Raviv Schaffer <raviv.schaffer@ibm.com>