### PR TITLE
Fix for returning empty result in case of Allow action in GRPC connector scenario

### DIFF
--- a/pkg/connectors/clients/policymanager_grpc.go
+++ b/pkg/connectors/clients/policymanager_grpc.go
@@ -345,21 +345,24 @@ func ConvertGrpcRespToOpenAPIResp(result *pb.PoliciesDecisions) (*openapiclientm
 				}
 
 				if level == pb.EnforcementAction_DATASET || level == pb.EnforcementAction_UNKNOWN {
-					actionOnDataset := openapiclientmodels.Action{}
 					if name == "Deny" {
+						actionOnDataset := openapiclientmodels.Action{}
 						actionOnDataset.SetName("Deny")
+						policyManagerResult.SetAction(actionOnDataset)
 					}
-					if name == "Allow" {
-						actionOnDataset.SetName("Allow")
-					}
-					policyManagerResult.SetAction(actionOnDataset)
 				}
 				if k < len(usedPoliciesList) {
 					policy := usedPoliciesList[k].GetDescription()
 					log.Println("usedPoliciesList[k].GetDescription()", policy)
 					policyManagerResult.SetPolicy(policy)
 				}
-				respResult = append(respResult, policyManagerResult)
+				if name != "Allow" {
+					// dont do anything For "Allow" action as this is convention now.
+					// If we pass empty resultitem it means allow
+					respResult = append(respResult, policyManagerResult)
+				} else {
+					log.Println("not doing any append to respResult for Allow action")
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This is a fix to the following error reported by Latha.
```
2021-10-06T05:42:18.647Z	INFO	controllers.FybrikApplication	Listing all modules
2021-10-06T05:42:18.648Z	INFO	controllers.FybrikApplication	arrow-flight-module
2021-10-06T05:42:18.648Z	INFO	controllers.FybrikApplication	Select modules for {"asset_id": "facbe568-f17a-4a86-acde-4bbb07405f2e", "context_type": "catalogs", "context_id": "c39a088c-3497-4c2e-bf72-e9c5db9b4cfd"}
2021-10-06T05:42:18.648Z	INFO	controllers.FybrikApplication	Select read path for {"asset_id": "facbe568-f17a-4a86-acde-4bbb07405f2e", "context_type": "catalogs", "context_id": "c39a088c-3497-4c2e-bf72-e9c5db9b4cfd"}
2021/10/06 05:42:18 constructed openapi request:  &base.PolicyManagerRequest{Context:(&map[string]interface{}){"intent":"Fraud Detection", "role":"Data Scientist"}, Action:base.PolicyManagerRequestAction{ActionType:(&base.ActionType)("read"), ProcessingLocation:(&string)("us"), Destination:(&string)("us")}, Resource:base.Resource{Name:"{\"asset_id\": \"facbe568-f17a-4a86-acde-4bbb07405f2e\", \"context_type\": \"catalogs\", \"context_id\": \"c39a088c-3497-4c2e-bf72-e9c5db9b4cfd\"}", Tags:(&map[string]interface{})(nil), Columns:(&[]base.ResourceColumns)(nil)}}
2021/10/06 05:42:18 open api request received for getting policy decisions:  {0xc00000f940 {0xc000d0e060 0xc000d0e070 0xc000d0e050} {{"asset_id": "facbe568-f17a-4a86-acde-4bbb07405f2e", "context_type": "catalogs", "context_id": "c39a088c-3497-4c2e-bf72-e9c5db9b4cfd"} <nil> <nil>}}
2021/10/06 05:42:18 processingGeo:  us
2021/10/06 05:42:18 Constructed GRPC appContext:  credential_path:"http://vault.fybrik-system:8200/v1/kubernetes-secrets/wkc-creds-fbcd6a72-6469-4f9d-a103-7a6307285952?namespace=fybrik-system-app"  app_info:{processing_geography:"us"  properties:{key:"intent"  value:"Fraud Detection"}  properties:{key:"role"  value:"Data Scientist"}}  datasets:{dataset:{dataset_id:"{\"asset_id\": \"facbe568-f17a-4a86-acde-4bbb07405f2e\", \"context_type\": \"catalogs\", \"context_id\": \"c39a088c-3497-4c2e-bf72-e9c5db9b4cfd\"}"}  operation:{type:READ  destination:"us"}}
2021/10/06 05:42:18 grpc application context to be used for getting policy decisions:  credential_path:"http://vault.fybrik-system:8200/v1/kubernetes-secrets/wkc-creds-fbcd6a72-6469-4f9d-a103-7a6307285952?namespace=fybrik-system-app"  app_info:{processing_geography:"us"  properties:{key:"intent"  value:"Fraud Detection"}  properties:{key:"role"  value:"Data Scientist"}}  datasets:{dataset:{dataset_id:"{\"asset_id\": \"facbe568-f17a-4a86-acde-4bbb07405f2e\", \"context_type\": \"catalogs\", \"context_id\": \"c39a088c-3497-4c2e-bf72-e9c5db9b4cfd\"}"}  operation:{type:READ  destination:"us"}}
2021/10/06 05:42:19 GRPC result returned from GetPoliciesDecisions: dataset_decisions:{dataset:{dataset_id:"{\"asset_id\": \"facbe568-f17a-4a86-acde-4bbb07405f2e\", \"context_type\": \"catalogs\", \"context_id\": \"c39a088c-3497-4c2e-bf72-e9c5db9b4cfd\"}"}  decisions:{operation:{type:READ  destination:"us"}  enforcement_actions:{name:"Allow"  id:"Allow-ID"  level:DATASET}  used_policies:{id:"no_active_policies"  type:"Policy"}  used_policies:{id:"admin_meta_rule"  type:"Rule"}}}
2021/10/06 05:42:19 decision id generated a70c6c310134247a348d4517d6258969083e2779
2021/10/06 05:42:19 args received:  map[]
2021/10/06 05:42:19 name received:  Allow
2021/10/06 05:42:19 level received:  DATASET
2021/10/06 05:42:19 usedPoliciesList[k].GetDescription() 
2021/10/06 05:42:19 policyManagerResp in convGrpcRespToOpenApiResp &{0xc000d03600 [{ {Allow map[]}}]}
2021/10/06 05:42:19 Marshalled value of policy manager response:  {
	"decision_id": "a70c6c310134247a348d4517d6258969083e2779",
	"result": [
		{
			"action": {
				"name": "Allow"
			},
			"policy": ""
		}
	]
}
2021/10/06 05:42:19 openapi response received from policy manager:  &base.PolicyManagerResponse{DecisionId:(&string)("a70c6c310134247a348d4517d6258969083e2779"), Result:[]base.ResultItem{base.ResultItem{Policy:"", Action:base.Action{Name:"Allow", AdditionalProperties:map[string]interface{}(nil)}}}}
2021-10-06T05:42:19.021Z	INFO	controllers.FybrikApplication	Checking supported read sources
2021-10-06T05:42:19.021Z	INFO	controllers.FybrikApplication	Copy is required because the read-path does not support all actions
2021-10-06T05:42:19.021Z	INFO	controllers.FybrikApplication	Unsupported actions:
2021-10-06T05:42:19.021Z	INFO	controllers.FybrikApplication		- policy: ""
  action:
    name: Allow
    additionalproperties: {}

2021-10-06T05:42:19.021Z	INFO	controllers.FybrikApplication	Copy is required for {"asset_id": "facbe568-f17a-4a86-acde-4bbb07405f2e", "context_type": "catalogs", "context_id": "c39a088c-3497-4c2e-bf72-e9c5db9b4cfd"}
2021-10-06T05:42:19.021Z	INFO	controllers.FybrikApplication	Could not find copy module for {"asset_id": "facbe568-f17a-4a86-acde-4bbb07405f2e", "context_type": "catalogs", "context_id": "c39a088c-3497-4c2e-bf72-e9c5db9b4cfd"}
2021-10-06T05:42:19.021Z	INFO	controllers.FybrikApplication	Could not select a copy module for {"asset_id": "facbe568-f17a-4a86-acde-4bbb07405f2e", "context_type": "catalogs", "context_id": "c39a088c-3497-4c2e-bf72-e9c5db9b4cfd"} : copy : no module has been registered
2021-10-06T05:42:19.021Z	INFO	controllers.FybrikApplication	Reconciled with errors: An error was received for asset {"asset_id": "facbe568-f17a-4a86-acde-4bbb07405f2e", "context_type": "catalogs", "context_id": "c39a088c-3497-4c2e-bf72-e9c5db9b4cfd"} . If the error persists, please contact an operator.Error description: copy : no module has been registered	{"fybrikapplication": "fybrik-system-app/fybrik-fbcd6a72-6469-4f9d-a103-7a6307285952"}

```Signed-off-by: Rohith D Vallam <rovallam@in.ibm.com>