### PR TITLE
Allow template string in FybrikModule hostname

### DIFF
--- a/charts/fybrik-crd/templates/app.fybrik.io_fybrikapplications.yaml
+++ b/charts/fybrik-crd/templates/app.fybrik.io_fybrikapplications.yaml
@@ -168,7 +168,7 @@ spec:
                       description: Endpoint provides the endpoint spec from which the asset will be served to the application
                       properties:
                         hostname:
-                          description: Always equals the release name. Can be omitted.
+                          description: Hostname is the hostname to connect to for connecting to a module exposed service. By default this equals {{ .Release.Name }}.{{ .Release.Namespace }} of the module. Module developers can overide the default behavior by providing a template that may use the .Release.Name, .Release.Namespace and .Values.labels variables.
                           type: string
                         port:
                           format: int32

--- a/charts/fybrik-crd/templates/app.fybrik.io_fybrikmodules.yaml
+++ b/charts/fybrik-crd/templates/app.fybrik.io_fybrikmodules.yaml
@@ -59,7 +59,7 @@ spec:
                           description: EndpointSpec is used both by the module creator and by the status of the fybrikapplication
                           properties:
                             hostname:
-                              description: Always equals the release name. Can be omitted.
+                              description: Hostname is the hostname to connect to for connecting to a module exposed service. By default this equals {{ .Release.Name }}.{{ .Release.Namespace }} of the module. Module developers can overide the default behavior by providing a template that may use the .Release.Name, .Release.Namespace and .Values.labels variables.
                               type: string
                             port:
                               format: int32

--- a/charts/fybrik-crd/templates/app.fybrik.io_plotters.yaml
+++ b/charts/fybrik-crd/templates/app.fybrik.io_plotters.yaml
@@ -183,7 +183,7 @@ spec:
                                             description: EndpointSpec is used both by the module creator and by the status of the fybrikapplication
                                             properties:
                                               hostname:
-                                                description: Always equals the release name. Can be omitted.
+                                                description: Hostname is the hostname to connect to for connecting to a module exposed service. By default this equals {{ .Release.Name }}.{{ .Release.Namespace }} of the module. Module developers can overide the default behavior by providing a template that may use the .Release.Name, .Release.Namespace and .Values.labels variables.
                                                 type: string
                                               port:
                                                 format: int32
@@ -221,7 +221,7 @@ spec:
                                                 description: EndpointSpec is used both by the module creator and by the status of the fybrikapplication
                                                 properties:
                                                   hostname:
-                                                    description: Always equals the release name. Can be omitted.
+                                                    description: Hostname is the hostname to connect to for connecting to a module exposed service. By default this equals {{ .Release.Name }}.{{ .Release.Namespace }} of the module. Module developers can overide the default behavior by providing a template that may use the .Release.Name, .Release.Namespace and .Values.labels variables.
                                                     type: string
                                                   port:
                                                     format: int32
@@ -298,7 +298,7 @@ spec:
                                 description: EndpointSpec is used both by the module creator and by the status of the fybrikapplication
                                 properties:
                                   hostname:
-                                    description: Always equals the release name. Can be omitted.
+                                    description: Hostname is the hostname to connect to for connecting to a module exposed service. By default this equals {{ .Release.Name }}.{{ .Release.Namespace }} of the module. Module developers can overide the default behavior by providing a template that may use the .Release.Name, .Release.Namespace and .Values.labels variables.
                                     type: string
                                   port:
                                     format: int32

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	emperror.dev/errors v0.7.0
 	fybrik.io/openapi2crd v0.4.0
 	github.com/IBM/satcon-client-go v0.1.2-0.20210329192404-b8fa1c732712
+	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/apache/arrow/go/arrow v0.0.0-20210907151234-f40856a768f2
 	github.com/aws/aws-sdk-go v1.40.37
 	github.com/buger/jsonparser v1.1.1
@@ -42,7 +43,6 @@ require (
 	github.com/rogpeppe/go-internal v1.6.0 // indirect
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.8.1
-	github.com/stoewer/go-strcase v1.2.0
 	github.com/stretchr/testify v1.7.0
 	github.com/tidwall/pretty v1.0.1
 	github.com/xeipuuv/gojsonschema v1.2.0

--- a/manager/apis/app/v1alpha1/fybrikmodule_types.go
+++ b/manager/apis/app/v1alpha1/fybrikmodule_types.go
@@ -91,7 +91,11 @@ type SupportedAction struct {
 
 // EndpointSpec is used both by the module creator and by the status of the fybrikapplication
 type EndpointSpec struct {
-	// Always equals the release name. Can be omitted.
+	// Hostname is the hostname to connect to for connecting to a module exposed service.
+	// By default this equals "{{ .Release.Name }}.{{ .Release.Namespace }}" of the module.
+	// <br/>
+	// Module developers can overide the default behavior by providing a template that may use
+	// the ".Release.Name", ".Release.Namespace" and ".Values.labels" variables.
 	// +optional
 	Hostname string `json:"hostname,omitempty"`
 	// +required

--- a/manager/controllers/app/fybrikapplication_controller_test.go
+++ b/manager/controllers/app/fybrikapplication_controller_test.go
@@ -155,7 +155,7 @@ var _ = Describe("FybrikApplication Controller", func() {
 			By("Status should contain the details of the endpoint")
 			Expect(len(application.Status.AssetStates)).To(Equal(1))
 			// TODO endpoint details are not set yet
-			fqdn := "test-app-e2e-default-read-module-test-e2e." + blueprintObjectKey.Namespace + ".svc.cluster.local"
+			fqdn := "test-app-e2e-default-read-module-test-e2e." + blueprintObjectKey.Namespace
 			Expect(application.Status.AssetStates["s3/redact-dataset"].Endpoint).To(Equal(apiv1alpha1.EndpointSpec{
 				Hostname: fqdn,
 				Port:     80,

--- a/manager/controllers/app/fybrikapplication_controller_unit_test.go
+++ b/manager/controllers/app/fybrikapplication_controller_unit_test.go
@@ -169,7 +169,7 @@ func TestFybrikApplicationControllerCSVCopyAndRead(t *testing.T) {
 	assetState := application.Status.AssetStates[application.Spec.Data[0].DataSetID]
 	g.Expect(assetState.Endpoint).To(gomega.Not(gomega.BeNil()))
 	g.Expect(assetState.Endpoint.Port).To(gomega.Equal(int32(80)))
-	g.Expect(assetState.Endpoint.Hostname).To(gomega.Equal("read-path"))
+	g.Expect(assetState.Endpoint.Hostname).To(gomega.Equal("read-path.notebook-default-arrow-flight-module.notebook"))
 	g.Expect(assetState.Endpoint.Scheme).To(gomega.Equal("grpc"))
 }
 

--- a/manager/testdata/unittests/module-read-csv.yaml
+++ b/manager/testdata/unittests/module-read-csv.yaml
@@ -19,7 +19,7 @@ spec:
         protocol: fybrik-arrow-flight
         dataformat: arrow
         endpoint:
-          hostname: read-path
+          hostname: read-path.{{ .Release.Name}}.{{ get .Values.labels "app" | default .Release.Namespace }}
           port: 80
           scheme: grpc
       supportedInterfaces:


### PR DESCRIPTION
Fix #846

- Allows `hostname` field in FybrikModule to be a templated string. Currently can use `.Release.Namespace`, `.Release.Name` and `.Values.labels`  (with just the FybrikApplication labels) as variables.
- The default no longer includes `.svc.cluster.local`.
- The CSVCopyAndRead test already had a custom hostname and is now changed to be a templated hostname.

