### PR TITLE
Quickstart update new opa policy

### DIFF
--- a/connectors/katalog/example/asset.yaml
+++ b/connectors/katalog/example/asset.yaml
@@ -23,7 +23,7 @@ spec:
         - PII
       oldbalanceOrg:
         tags:
-        - sensitive
+        - PII
       newbalanceOrig:
         tags:
-        - sensitive
+        - PII

--- a/connectors/open_policy_agent/lib/opa_reader.go
+++ b/connectors/open_policy_agent/lib/opa_reader.go
@@ -46,9 +46,13 @@ func (r *OpaReader) updatePolicyManagerRequestWithResourceInfo(in *openapiclient
 
 					tagVal := make(map[string]interface{})
 					for i := 0; i < len(tagArr); i++ {
-						splitStr := strings.Split(tagArr[i], " = ")
-						// residency = Turkey
-						tagVal[splitStr[0]] = splitStr[1]
+						if strings.Contains(tagArr[i], " = ") {
+							splitStr := strings.Split(tagArr[i], " = ")
+							// residency = Turkey
+							tagVal[splitStr[0]] = splitStr[1]
+						} else {
+							tagVal[tagArr[i]] = ""
+						}
 					}
 					log.Println("tagVal: ", tagVal)
 					resource := in.GetResource()

--- a/site/docs/samples/notebook.md
+++ b/site/docs/samples/notebook.md
@@ -122,16 +122,16 @@ Notice the `assetMetadata` field above. It specifies the dataset geography and t
 
 ## Define data access policies
 
-Define an [OpenPolicyAgent](https://www.openpolicyagent.org/) policy to redact the `nameOrig` column for datasets tagged as `finance`. Below is the policy (written in [Rego](https://www.openpolicyagent.org/docs/latest/policy-language/#what-is-rego) language):
+Define an [OpenPolicyAgent](https://www.openpolicyagent.org/) policy to redact the columns which are tagged with `PII` for datasets which have data tags as `finance`. Below is the policy (written in [Rego](https://www.openpolicyagent.org/docs/latest/policy-language/#what-is-rego) language):
 
 ```rego
 package dataapi.authz
 
 rule[{"action": {"name":"RedactAction", "columns": column_names}, "policy": description}] {
-  description := "Redact sensitive columns in finance datasets"
+  description := "Redact columns tagged as PII in datasets tagged with finance = true"
   input.action.actionType == "read"
   input.resource.tags.finance
-  column_names := [input.resource.columns[i].name | input.resource.columns[i].name == "nameOrig"]
+  column_names := [input.resource.columns[i].name | input.resource.columns[i].tags.PII]
 }
 ```
 


### PR DESCRIPTION
This PR completes the following tasks:

- Modifies the OPA policy in quickstart to conform with the taxonomy
- Changed `asset.yaml` so that each column is tagged as `PII`
- Changed `opa_reader.go` file to handle a stand alone data tag such as `finance`

Need to test if the quickstart is working fine or not. Once, it is done this PR will be moved out of draft.