### PR TITLE
Use url parsing to extract the endpoint

### DIFF
--- a/manager/controllers/app/plotter_generator.go
+++ b/manager/controllers/app/plotter_generator.go
@@ -57,6 +57,8 @@ func (p *PlotterGenerator) GetCopyDestination(item DataInfo, destinationInterfac
 		return nil, err
 	}
 
+	// S3 endpoint should not include the url scheme only the host name
+	// thus ignoring it if such exists.
 	url, err := url.Parse(bucket.Endpoint)
 	if err != nil {
 		return nil, err

--- a/pkg/connectors/protos/dataset_details.proto
+++ b/pkg/connectors/protos/dataset_details.proto
@@ -38,7 +38,7 @@ message Db2DataStore {
 }
 
 message S3DataStore {
-    string endpoint = 1;
+    string endpoint = 1;    // endpoint should contain only the host name without the scheme i.e., "s3.eu-gb.cloud-object-storage.appdomain.cloud"
     string bucket = 2;
     string object_key = 3; //can be object name or the prefix for dataset
     string region = 4;     // WKC does not return it, it will stay empty in our case!!!


### PR DESCRIPTION
This PR replaces the hard-coded check for HTTP prefix with URL parsing