### PR TITLE
CI: improve releasing workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,6 @@ name: Build
 on:
   push:
     branches-ignore:
-      - 'releases/**'
       - 'site'
     tags:
       - '*'

--- a/.github/workflows/release-branch.yaml
+++ b/.github/workflows/release-branch.yaml
@@ -18,4 +18,3 @@ jobs:
     - uses: EndBug/add-and-commit@v7
       with:
         default_author: github_actions
-        tag: 'v${{ steps.version.outputs.version }}'


### PR DESCRIPTION
Related to #888 

# Changes
* Run Build workflow on releases/** branches
* Do not automatically tag a releases/** branch

# Release workflow after this PR
- Manually create a branch `releases/X.Y.Z` either from `master` or an existing `releases/.X.Y.(Z-1)` branch
    - Automatically updates the code to include the X.Y.Z version number
    - Runs the Build workflow
- When ready to publish the release create a GitHub release with `vX.Y.Z` tag from `releases/X.Y.Z`
   - Automatically creates a PR to the charts repo 
  
