### PR TITLE
Modifying copy modules' templates to work with a new Action structure

### DIFF
--- a/modules/fybrik-implicit-copy-batch/templates/batchtransfer.yaml
+++ b/modules/fybrik-implicit-copy-batch/templates/batchtransfer.yaml
@@ -61,15 +61,15 @@ spec:
   {{ range .Values.copy.transformations }}
   {{ if eq .name "RedactAction" }}
   - action: "RedactColumns"
-    name: "redacting column: {{ .args.column_name }}"
-    columns: [ {{ .args.column_name | quote }} ]
+    name: "redacting columns: {{ .RedactAction.columns }}"
+    columns: {{ .RedactAction.columns }} 
     options:
       redactValue: "XXXXXX"
   {{ end }}
   {{ if eq .name "RemoveAction" }}
   - action: "RemoveColumns"
-    name: "redacting column: {{ .args.column_name }}"
-    columns: [ "{{ .args.column_name }}" ]
+    name: "redacting columns: {{ .RemoveAction.columns }}"
+    columns: {{ .RemoveAction.columns }}
   {{ end }}
   {{ end }}
   {{ end }}

--- a/modules/fybrik-implicit-copy-batch/values.yaml.sample
+++ b/modules/fybrik-implicit-copy-batch/values.yaml.sample
@@ -38,8 +38,13 @@ copy:
 
   transformations:
   - name: "RedactAction"
-    args:
-      column_name: col1
+    RedactAction:
+      columns: 
+      - col1
+      - col2
   - name: "RemoveAction"
-    args:
-      column_name: col2
+    RemoveAction:
+      columns: 
+      - col1
+      - col2
+  

--- a/modules/fybrik-implicit-copy-stream/templates/streamtransfer.yaml
+++ b/modules/fybrik-implicit-copy-stream/templates/streamtransfer.yaml
@@ -41,15 +41,15 @@ spec:
   {{ range .Values.copy.transformations }}
   {{ if eq .name "RedactAction" }}
   - action: "RedactColumns"
-    name: "redacting column: {{ .args.column_name }}"
-    columns: [ {{ .args.column_name | quote }} ]
+    name: "redacting columns: {{ .RedactAction.columns }}"
+    columns:  {{ .RedactAction.columns }} 
     options:
       redactValue: "XXXXXX"
   {{ end }}
   {{ if eq .name "RemoveAction" }}
   - action: "RemoveColumns"
-    name: "redacting column: {{ .args.column_name }}"
-    columns: [ "{{ .args.column_name }}" ]
+    name: "redacting column: {{ .RemoveAction.columns }}"
+    columns: {{ .RemoveAction.columns }}
   {{ end }}
   {{ end }}
   {{ end }}

--- a/modules/fybrik-implicit-copy-stream/values.yaml.sample
+++ b/modules/fybrik-implicit-copy-stream/values.yaml.sample
@@ -35,9 +35,11 @@ copy:
         secretPath: "/v1/kubernetes-secrets/secret-name?namespace=default"
 
   transformations:
-  - args:
-      column: SSN
+  - RedactAction:
+      columns: 
+      - SSN
     name: RedactAction
-  - args:
-      column: BLOOD_TYPE
+  - EncryptAction:
+      columns: 
+      - BLOOD_TYPE
     name: EncryptAction


### PR DESCRIPTION
Signed-off-by: Shlomit Koyfman <shlomitk@il.ibm.com>

This PR changes the templated version of batchtransfer and streamtransfer to support a new Action structure from the taxonomy.