### PR TITLE
Bump golangci-lint version

### DIFF
--- a/hack/make-rules/tools.mk
+++ b/hack/make-rules/tools.mk
@@ -22,7 +22,7 @@ $(TOOLBIN)/helm:
 
 INSTALL_TOOLS += $(TOOLBIN)/golangci-lint
 $(TOOLBIN)/golangci-lint:
-	GOBIN=$(ABSTOOLBIN) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.31.0
+	GOBIN=$(ABSTOOLBIN) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1
 	$(call post-install-check)
 
 INSTALL_TOOLS += $(TOOLBIN)/kubebuilder


### PR DESCRIPTION
Using the current version I'm getting a segfault with golang 1.17.2 .
Bumping the version resolves this.

Although it seems that the whole project will be deprecated soon and will be replaced by https://github.com/mgechev/revive