### PR TITLE
Policy fixes with count columns

### DIFF
--- a/site/docs/samples/notebook.md
+++ b/site/docs/samples/notebook.md
@@ -132,6 +132,7 @@ rule[{"action": {"name":"RedactAction", "columns": column_names}, "policy": desc
   input.action.actionType == "read"
   input.resource.tags.finance
   column_names := [input.resource.columns[i].name | input.resource.columns[i].tags.PII]
+  count(column_names) > 0
 }
 ```
 

--- a/third_party/opa/data-and-policies/policies-think2021-demo/sample_policies.rego
+++ b/third_party/opa/data-and-policies/policies-think2021-demo/sample_policies.rego
@@ -9,6 +9,7 @@ rule[{"action": {"name":"RedactAction", "columns": column_names}, "policy": desc
 	input.resource.tags.residency == "Turkey"
 	input.action.processingLocation != "Turkey"
 	column_names := [input.resource.columns[i].name | input.resource.columns[i].tags.Confidential]
+	count(column_names) > 0
 }
 
 rule[{"action": {"name":"Deny"}, "policy": description}] {


### PR DESCRIPTION
This PR fixes policies in:

1. quickstart policy
2. sample_policies.rego

with count(column_names) > 0

Signed-off-by: ritwikc <charitwi@in.ibm.com>