### PR TITLE
workflows: Add fybrik bot for cherry-picks

### DIFF
--- a/.github/workflows/chart-publish.yaml
+++ b/.github/workflows/chart-publish.yaml
@@ -29,8 +29,8 @@ jobs:
       - uses: tibdex/github-app-token@v1
         id: generate-token
         with:
-          app_id: ${{ secrets.CHARTS_APP_ID }}
-          private_key: ${{ secrets.CHARTS_APP_PRIVATE_KEY }}
+          app_id: ${{ secrets.FYBRIK_BOT_APP_ID }}
+          private_key: ${{ secrets.FYBRIK_BOT_PRIVATE_KEY }}
           repository: fybrik/charts
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/cherry-pick-command.yml
+++ b/.github/workflows/cherry-pick-command.yml
@@ -1,0 +1,85 @@
+name: cherry-pick-command
+on:
+  workflow_dispatch:
+    inputs:
+      comment-id:
+        description: "The comment-id of the slash command"
+        required: false
+      pull-request:
+        description: "The PR number to cherry pick from"
+        required: true
+      branch:
+        description: "The branch name to cherry pick to"
+        required: true
+jobs:
+  cherry-pick:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate bot token
+        uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.FYBRIK_BOT_APP_ID }}
+          private_key: ${{ secrets.FYBRIK_BOT_PRIVATE_KEY }}
+          repository: ${{ github.repository }}
+
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.branch }}
+
+      - name: Setup git
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "noreply@github.com"
+
+      - name: Create Pull Request branch name
+        id: temp_branch
+        run: echo "::set-output name=branch::cherry-pick-${{ github.event.inputs.pull-request }}-${{ github.event.inputs.branch }}"
+
+      - name: Get Pull Request branch
+        run: git fetch origin pull/${{ github.event.inputs.pull-request }}/head:${{ steps.temp_branch.outputs.branch }}
+
+      - name: Cherry-pick commits
+        shell: pwsh
+        run: |
+          $pullId = "${{ github.event.inputs.pull-request }}"
+          $url = $("${{ github.event.repository.pulls_url}}".Replace("{/number}", "/$pullId")) + "/commits"
+          $headers = @{ "Authorization" = "token ${{ secrets.GITHUB_TOKEN }}"; "User-Agent" = "GitHub Actions Bot"; "Accept" = "application/vnd.github.v3+json" }
+          $response = Invoke-RestMethod -Uri $url -Headers $headers
+          $response | ForEach-Object {
+            git cherry-pick $_.sha
+          }
+
+      - name: Push
+        run: git push origin ${{ steps.temp_branch.outputs.branch }}
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          title: "cherry-pick from #${{ github.event.inputs.pull-request }} into ${{ github.event.inputs.branch }}"
+          body: "cherry-pick from #${{ github.event.inputs.pull-request }} into ${{ github.event.inputs.branch }}"
+          branch: ${{ steps.temp_branch.outputs.branch }}
+          delete-branch: true
+
+      - name: Add reaction
+        if: ${{ github.event.inputs.comment-id }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          repository: ${{ github.repository }}
+          issue-number: ${{ github.event.inputs.pull-request }}
+          comment-id: ${{ github.event.inputs.comment-id }}
+          reaction-type: hooray
+
+      - name: Add failure reaction
+        if: ${{ failure() && github.event.inputs.comment-id }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          repository: ${{ github.repository }}
+          issue-number: ${{ github.event.inputs.pull-request }}
+          comment-id: ${{ github.event.inputs.comment-id }}
+          reaction-type: "-1"
+          body: |
+            > Failed - see https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/slash_commands.yml
+++ b/.github/workflows/slash_commands.yml
@@ -1,0 +1,36 @@
+name: Slash Command Dispatch
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  slashCommandDispatch:
+    if: ${{ github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.FYBRIK_BOT_APP_ID }}
+          private_key: ${{ secrets.FYBRIK_BOT_PRIVATE_KEY }}
+          repository: ${{ github.repository }}
+      - name: Slash Command Dispatch
+        id: scd
+        uses: peter-evans/slash-command-dispatch@v2
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          commands: |
+            cherry-pick
+          dispatch-type: workflow
+          reactions: false
+          static-args: |
+            comment-id=${{ github.event.comment.id }}
+            pull-request=${{ github.event.issue.number }}
+      - name: Edit comment with error message
+        if: steps.scd.outputs.error-message
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          comment-id: ${{ github.event.comment.id }}
+          body: |
+            > ${{ steps.scd.outputs.error-message }}
+          reaction-type: confused


### PR DESCRIPTION
If there is a PR merged to master and you want to backport it to the `releases/x.y.z` branch then you can comment on the PR with:
```
/cherry-pick branch=releases/x.y.z
```

Note that a fybrik-bot github application is used and it replaces the older m4d-charts-bot.


Closes #910