### PR TITLE
Add job to the build workflow for the notebook sample.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,6 +102,31 @@ jobs:
         path: images.tar
         retention-days: 1
 
+  notebook-sample:
+    name: Notebook sample
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_HOSTNAME: "localhost:5000"
+      DOCKER_NAMESPACE: fybrik-system
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ env.GO_VERSION }}
+    - uses: actions/checkout@v2
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/go/pkg/mod
+          ${{ github.workspace }}/hack/tools/bin
+        key: ${{ runner.os }}-t-${{ hashFiles('hack/make-rules/tools.mk') }}-m2-${{ hashFiles('**/pom.xml') }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: ${{ runner.os }}-t-${{ hashFiles('hack/make-rules/tools.mk') }}-go
+    - name: Install tools
+      run: make install-tools
+    - name: Notebook tests
+      run: make run-notebook-tests
+
   tekton-pipelines:
     name: Tekton Tests
     runs-on: ubuntu-latest

--- a/manager/Makefile
+++ b/manager/Makefile
@@ -1,3 +1,4 @@
+SHELL := /bin/bash
 ROOT_DIR := ..
 include $(ROOT_DIR)/Makefile.env
 #include Makefile.env

--- a/manager/Makefile
+++ b/manager/Makefile
@@ -1,4 +1,3 @@
-SHELL := /bin/bash
 ROOT_DIR := ..
 include $(ROOT_DIR)/Makefile.env
 #include Makefile.env
@@ -84,7 +83,7 @@ run-notebook-tests: export DOCKER_NAMESPACE?=fybrik-system
 run-notebook-tests: export DOCKER_TAGNAME?=master
 run-notebook-tests: export USE_MOCKUP_CONNECTOR?=true
 run-notebook-tests: wait_for_manager
-	pushd testdata/notebook && ./setup.sh && popd
+	cd testdata/notebook && ./setup.sh
 	NO_SIMULATED_PROGRESS=true USE_EXISTING_CONTROLLER=true USE_EXISTING_CLUSTER=true go test ./... -v -run TestS3Notebook -count 1
 
 

--- a/manager/controllers/app/fybrik_notebook_test.go
+++ b/manager/controllers/app/fybrik_notebook_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega"
 	"google.golang.org/grpc"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -38,12 +38,13 @@ type ArrowRequest struct {
 	Columns []string `json:"columns,omitempty"`
 }
 
-// TODO Refactor this test to be called from within the suite
 func TestS3Notebook(t *testing.T) {
 	if s, ok := os.LookupEnv("VALUES_FILE"); !ok || s != "charts/fybrik/notebook-tests.values.yaml" {
 		t.Skip("Only executed for notebook tests")
 	}
-	RegisterFailHandler(Fail)
+	gomega.RegisterFailHandler(Fail)
+
+	g := gomega.NewGomegaWithT(t)
 	defer GinkgoRecover()
 
 	// Copy data.csv file to S3
@@ -70,7 +71,7 @@ func TestS3Notebook(t *testing.T) {
 		uploader := s3manager.NewUploader(sess)
 
 		f, ferr := os.Open(filename)
-		Expect(ferr).To(BeNil(), "Opening local test data file")
+		g.Expect(ferr).To(gomega.BeNil(), "Opening local test data file")
 
 		// Upload the file to S3.
 		result, err := uploader.Upload(&s3manager.UploadInput{
@@ -78,20 +79,20 @@ func TestS3Notebook(t *testing.T) {
 			Key:    aws.String(key1),
 			Body:   f,
 		})
-		Expect(err).To(BeNil(), "S3 upload")
+		g.Expect(err).To(gomega.BeNil(), "S3 upload")
 		if result != nil {
 			log.Println(fmt.Sprintf("file uploaded to, %s\n", result.Location))
 		}
 	} else {
-		Expect(object).ToNot(BeNil())
+		g.Expect(object).ToNot(gomega.BeNil())
 		log.Println("Object already exists in S3!")
 	}
 
 	err = apiv1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
+	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	k8sClient, err := client.New(ctrl.GetConfigOrDie(), client.Options{Scheme: scheme.Scheme})
-	Expect(err).To(BeNil())
+	g.Expect(err).To(gomega.BeNil())
 
 	// Create Kubernetes objects for test
 	// - namespace (in setup before)
@@ -105,12 +106,12 @@ func TestS3Notebook(t *testing.T) {
 	// Module installed by setup script directly from remote arrow-flight-module repository
 	// Installing application
 	application := &apiv1alpha1.FybrikApplication{}
-	Expect(readObjectFromFile("../../testdata/notebook/fybrikapplication.yaml", application)).ToNot(HaveOccurred())
+	g.Expect(readObjectFromFile("../../testdata/notebook/fybrikapplication.yaml", application)).ToNot(gomega.HaveOccurred())
 	applicationKey := client.ObjectKeyFromObject(application)
 
 	// Create FybrikApplication and FybrikModule
 	By("Expecting application creation to succeed")
-	Expect(k8sClient.Create(context.Background(), application)).Should(Succeed())
+	g.Expect(k8sClient.Create(context.Background(), application)).Should(gomega.Succeed())
 
 	// Ensure getting cleaned up after tests finish
 	defer func() {
@@ -120,31 +121,31 @@ func TestS3Notebook(t *testing.T) {
 	}()
 
 	By("Expecting application to be created")
-	Eventually(func() error {
+	g.Eventually(func() error {
 		return k8sClient.Get(context.Background(), applicationKey, application)
-	}, timeout, interval).Should(Succeed())
+	}, timeout, interval).Should(gomega.Succeed())
 	By("Expecting plotter to be constructed")
-	Eventually(func() *apiv1alpha1.ResourceReference {
+	g.Eventually(func() *apiv1alpha1.ResourceReference {
 		_ = k8sClient.Get(context.Background(), applicationKey, application)
 		return application.Status.Generated
-	}, timeout, interval).ShouldNot(BeNil())
+	}, timeout, interval).ShouldNot(gomega.BeNil())
 
 	// The plotter has to be created
 	plotter := &apiv1alpha1.Plotter{}
 	plotterObjectKey := client.ObjectKey{Namespace: application.Status.Generated.Namespace, Name: application.Status.Generated.Name}
 	By("Expecting plotter to be fetchable")
-	Eventually(func() error {
+	g.Eventually(func() error {
 		return k8sClient.Get(context.Background(), plotterObjectKey, plotter)
-	}, timeout, interval).Should(Succeed())
+	}, timeout, interval).Should(gomega.Succeed())
 
 	By("Expecting application to be ready")
-	Eventually(func() bool {
+	g.Eventually(func() bool {
 		err := k8sClient.Get(context.Background(), applicationKey, application)
 		if err != nil {
 			return false
 		}
 		return application.Status.Ready
-	}, timeout, interval).Should(Equal(true))
+	}, timeout, interval).Should(gomega.Equal(true))
 
 	blueprintNamespace := utils.GetBlueprintNamespace()
 	fmt.Printf("blueprint namespace notebook test: %s\n", blueprintNamespace)
@@ -155,13 +156,13 @@ func TestS3Notebook(t *testing.T) {
 
 	By("Starting kubectl port-forward for arrow-flight")
 	listenPort, err := test.RunPortForward(blueprintNamespace, svcName, int(port))
-	Expect(err).To(BeNil())
+	g.Expect(err).To(gomega.BeNil())
 
 	// Reading data via arrow flight
 	opts := make([]grpc.DialOption, 0)
 	opts = append(opts, grpc.WithInsecure())
 	flightClient, err := flight.NewFlightClient(net.JoinHostPort("localhost", listenPort), nil, opts...)
-	Expect(err).To(BeNil(), "Connect to arrow-flight service")
+	g.Expect(err).To(gomega.BeNil(), "Connect to arrow-flight service")
 	defer flightClient.Close()
 
 	request := ArrowRequest{
@@ -169,35 +170,35 @@ func TestS3Notebook(t *testing.T) {
 	}
 
 	marshal, err := json.Marshal(request)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(gomega.BeNil())
 
 	info, err := flightClient.GetFlightInfo(context.Background(), &flight.FlightDescriptor{
 		Type: flight.FlightDescriptor_CMD,
 		Cmd:  marshal,
 	})
-	Expect(err).To(BeNil())
+	g.Expect(err).To(gomega.BeNil())
 
 	stream, err := flightClient.DoGet(context.Background(), info.Endpoint[0].Ticket)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(gomega.BeNil())
 
 	reader, err := flight.NewRecordReader(stream)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(gomega.BeNil())
 	for reader.Next() {
 		record := reader.Record()
 		defer record.Release()
-		Expect(record.ColumnName(0)).To(Equal("step"))
-		Expect(record.ColumnName(1)).To(Equal("type"))
-		Expect(record.ColumnName(3)).To(Equal("nameOrig"))
+		g.Expect(record.ColumnName(0)).To(gomega.Equal("step"))
+		g.Expect(record.ColumnName(1)).To(gomega.Equal("type"))
+		g.Expect(record.ColumnName(3)).To(gomega.Equal("nameOrig"))
 		column := record.Column(3) // Check out the third 4th column that should be nameOrig and redacted
 
 		// Check that data of nameOrig column is the correct size and all records are redacted
 		dt := column.Data().DataType()
-		Expect(column.Data().Len()).To(Equal(100))
-		Expect(dt.ID()).To(Equal(arrow.STRING))
-		Expect(dt.Name()).To(Equal((&arrow.StringType{}).Name()))
+		g.Expect(column.Data().Len()).To(gomega.Equal(100))
+		g.Expect(dt.ID()).To(gomega.Equal(arrow.STRING))
+		g.Expect(dt.Name()).To(gomega.Equal((&arrow.StringType{}).Name()))
 		data := array.NewStringData(column.Data())
 		for i := 0; i < data.Len(); i++ {
-			Expect(data.Value(i)).To(Equal("XXXXX"))
+			g.Expect(data.Value(i)).To(gomega.Equal("XXXXX"))
 		}
 	}
 }


### PR DESCRIPTION
This PR adds a job to the build workflow for the notebook sample.
It also contains additional two fixes:
- added `SHELL := /bin/bash` to the manager/Makefile to avoid failing on `pushd` command
- calls `NewGomegaWithT` in the sample test to make gomega functions work properly. 