### PR TITLE
Update site docs - module changes and env

### DIFF
--- a/site/docs/contribute/environment.md
+++ b/site/docs/contribute/environment.md
@@ -31,6 +31,8 @@ make install-tools
 
 This installs additional dependencies to `hack/tools/bin`. The `make` targets (e.g., `make test`) are configured to use the binaries from `hack/tools/bin`. However, you may want to add some of these tools to your system PATH for direct usage from your terminal (e.g., for using `kubectl`).
 
+Please note: For version 0.5 and lower of fybrik, Helm version greater than 3.3 but less than 3.7 is required.
+
 ## Editors
 
 The project is predominantly written in Go so we recommend [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.Go) for its good Go support. Alternatively you can select from [Editors](https://golang.org/doc/editors.html)
@@ -44,4 +46,7 @@ a docker registry as a proxy for all public images. This registry runs in a dock
 ```shell
 export DOCKER_USERNAME='your github username'
 export DOCKER_PASSWORD='your github personal develper token'
+
+export DOCKERHUB_USERNAME='your docker hub username'
+export DOCKERHUB_PASSWORD='your password'
 ```

--- a/site/docs/contribute/environment.md
+++ b/site/docs/contribute/environment.md
@@ -31,7 +31,7 @@ make install-tools
 
 This installs additional dependencies to `hack/tools/bin`. The `make` targets (e.g., `make test`) are configured to use the binaries from `hack/tools/bin`. However, you may want to add some of these tools to your system PATH for direct usage from your terminal (e.g., for using `kubectl`).
 
-Please note: For version 0.5 and lower of fybrik, Helm version greater than 3.3 but less than 3.7 is required.
+Please note: For fybrik version 0.5 and lower, Helm version greater than 3.3 but less than 3.7 is required when contributing.
 
 ## Editors
 
@@ -44,9 +44,6 @@ One option to fix the limit is to use a docker hub login for downloading the ima
 a docker registry as a proxy for all public images. This registry runs in a docker container next to the kind clusters. 
 
 ```shell
-export DOCKER_USERNAME='your github username'
-export DOCKER_PASSWORD='your github personal develper token'
-
 export DOCKERHUB_USERNAME='your docker hub username'
 export DOCKERHUB_PASSWORD='your password'
 ```

--- a/site/docs/contribute/environment.md
+++ b/site/docs/contribute/environment.md
@@ -36,11 +36,12 @@ This installs additional dependencies to `hack/tools/bin`. The `make` targets (e
 The project is predominantly written in Go so we recommend [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.Go) for its good Go support. Alternatively you can select from [Editors](https://golang.org/doc/editors.html)
 
 ## Docker hub rate limits
+
 As docker hub introduced rate limits on docker image downloads this may effect development using the local kind setup.
 One option to fix the limit is to use a docker hub login for downloading the images. The environment will run
 a docker registry as a proxy for all public images. This registry runs in a docker container next to the kind clusters. 
 
 ```shell
-export DOCKERHUB_USERNAME='your docker hub username'
-export DOCKERHUB_PASSWORD='your password'
+export DOCKER_USERNAME='your github username'
+export DOCKER_PASSWORD='your github personal develper token'
 ```

--- a/site/docs/contribute/modules.md
+++ b/site/docs/contribute/modules.md
@@ -70,6 +70,9 @@ apiVersion: app.fybrik.io/v1alpha1 # always this value
 kind: FybrikModule # always this value
 metadata:
   name: "<module name>" # the name of your new module
+  labels:
+    name: "<module name>" # the name of your new module
+    version: "<semantic version>"
   namespace: fybrik-system  # control plane namespace. Always fybrik-system
 spec:
    ...
@@ -83,7 +86,10 @@ This is a link to a the Helm chart stored in the [image registry]( https://helm.
 
 ```
 spec:
-  chart: "<helm chart link>" # e.g.: ghcr.io/username/chartname:chartversion
+  chart: 
+    name: "<helm chart link>" # e.g.: ghcr.io/username/
+    values:
+      image.tag: v0.0.1
 ```
 
 ### `spec.statusIndicators`
@@ -114,41 +120,63 @@ dependencies:
 
 The `type` field may be one of the following vaues:
 
-1)service - Indicates that module workload implements the modules logic, and is deployed for every workload.
+1)service - Indicates that module workload implements the modules logic, and is deployed by the fybrik control plane.
 
 2) config - In this case the logic is performed by a component deployed externally, i.e. not by the fybrik control plane.  Such components can be assumed to support multiple workloads.
 
-3) plugin - This type of module enables a sub-set of often used capabilities to be implemented once and re-used by any module that supports plugins of the declared type.
+3) plugin (FUTURE) - This type of module enables a sub-set of often used capabilities to be implemented once and re-used by any module that supports plugins of the declared type.
 
 ### `spec.pluginType`
+
+(Future Functionality)
 The types of plugins supported by this module.  Example: vault, fybrik-wasm ...
 
+
 ### `spec.capabilities`
+
 Each module may support one or more capabilities.  Currently there are four capabilities: `read` for enabling an application to read data or prepare data for being read, `write` for enabling an application to write data, and `copy` for performing an implicit data copy on behalf of the application, and `transform` for altering data based on governance policies. A module provides one or more of these capabilities.  
  
+`capabilities.capability`
+
+Indicates which of the types of capabilities this instance describes.
 
 ```yaml
-capabilityType: # Indicate the data flow(s) in which the control plane should consider using this module 
+capability: # Indicate the capabilities for which the control plane should consider using this module 
 - read  # optional
 - write # optional
 - copy  # optional
 - transform # optional
 ```
 
-### `spec.capabilities`
+`capability.scope`
 
-`capabilites.supportedInterfaces` lists the supported data services from which the module can read data and to which it can write 
-* `scope` indicate whether the capability acts on the `asset`, `workload` or `cluster` level
+The capability provided by the module may work on one of several different scopes:
+
+* workload - deployed once by fybrik and available for use by the data planes of all the datasets
+* asset - deployed by fybrik for each dataset
+* cluster - deployed outside of fybrik and can be used by multiple fybbrik workloads in a given cluster
+
+```yaml
+scope: <scope of the capability> # cluster, workload, asset
+```
+
+`capabilites.supportedInterfaces` 
+
+Lists the supported data services from which the module can read data (sources) and to which it can write (sinks).  There can be multiple sources and sinks.  For each, a protocol and format are provided.
+
 * `protocol` field can take a value such as `kafka`, `s3`, `jdbc-db2`, `fybrik-arrow-flight`, etc.
 * `format` field can take a value such as `avro`, `parquet`, `json`, or `csv`.
+
 Note that a module that targets copy flows will omit the `api` field and contain just `source` and `sink`, a module that only supports reading data assets will omit the `sink` field and only contain `api` and `source`
 
-`capabilites.api` describes the api exposed by the module to the user's workload for the particular capability:
+`capabilites.api` describes the api exposed by the module to the user's workload for the particular capability.
+
 * `protocol` field can take a value such as `kafka`, `s3`, `jdbc-db2`, `fybrik-arrow-flight`, etc 
 * `dataformat` field can take a value such as `parquet`, `csv`, `arrow`, etc
 * `endpoint` field describes the endpoint exposed the module
 
 `capabilites.api.endpoint` describes the endpoint from a networking perspective:
+
 * `hostname` field is the hostname to be used when accessing the module. Equals the release name. Can be omitted.
 * `port` field is the port of the service exposed by the module.
 * `scheme` field can take a value such as `http`, `https`, `grpc`, `grpc+tls`, `jdbc:oracle:thin:@`, etc
@@ -191,7 +219,7 @@ capabilities:
 `capabilites.actions`  are taken from a defined [Enforcement Actions Taxonomy](about:blank) 
 a module that does not perform any transformation on the data may omit the `capabilities.actions` field.
 
-The following is an example of how a module would declare that it knows how to redact, remove or encrypt data.
+The following is an example of how a module would declare that it knows how to redact, remove or encrypt data.  Additional properties may be associated with each action.
 
 ```yaml
 capabilities:

--- a/site/docs/contribute/modules.md
+++ b/site/docs/contribute/modules.md
@@ -87,7 +87,7 @@ This is a link to a the Helm chart stored in the [image registry]( https://helm.
 ```
 spec:
   chart: 
-    name: "<helm chart link>" # e.g.: ghcr.io/username/
+    name: "<helm chart link>" # e.g.: ghcr.io/username/chartname:chartversion
     values:
       image.tag: v0.0.1
 ```

--- a/site/docs/get-started/quickstart.md
+++ b/site/docs/get-started/quickstart.md
@@ -8,7 +8,7 @@ Follow this guide to install Fybrik using default parameters that are suitable f
 
 Ensure that you have the following:
 
-- [Helm](https://helm.sh/) 3.3 or greater but less than 3.7 must be installed and configured on your machine.
+- [Helm](https://helm.sh/) 3.3 or greater must be installed and configured on your machine.
 - [Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) 1.18 or newer must be installed on your machine.
 - Access to a Kubernetes cluster such as [Kind](http://kind.sigs.k8s.io/) as a cluster administrator.
 

--- a/site/docs/get-started/quickstart.md
+++ b/site/docs/get-started/quickstart.md
@@ -8,7 +8,7 @@ Follow this guide to install Fybrik using default parameters that are suitable f
 
 Ensure that you have the following:
 
-- [Helm](https://helm.sh/) 3.3 or newer must be installed and configured on your machine.
+- [Helm](https://helm.sh/) 3.3 or greater but less than 3.7 must be installed and configured on your machine.
 - [Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) 1.18 or newer must be installed on your machine.
 - Access to a Kubernetes cluster such as [Kind](http://kind.sigs.k8s.io/) as a cluster administrator.
 


### PR DESCRIPTION
Updating the the documentation for
1. how to contribute modules (Fixes https://github.com/fybrik/fybrik/issues/831)

2. helm version requirement (as per the problem described in https://github.com/fybrik/fybrik/issues/817)
3. docker_username and docker_password environment variables

Should we also merge this into V0.5?