### PR TITLE
Avoid using ClusterRole if clusterScope value is false in Vault helm …

### DIFF
--- a/charts/vault/templates/vault-crb.yaml
+++ b/charts/vault/templates/vault-crb.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.plugins.vaultPluginSecretsKubernetesReader.clusterScope true }}
+{{- if .Values.plugins.vaultPluginSecretsKubernetesReader.clusterScope }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/charts/vault/templates/vault-rb.yaml
+++ b/charts/vault/templates/vault-rb.yaml
@@ -9,7 +9,7 @@ subjects:
   name:  vault
   namespace: {{ $.Release.Namespace }}
 roleRef:
-  kind: ClusterRole
+  kind: Role
   name: vault-secrets-manager
   apiGroup: rbac.authorization.k8s.io
 ---

--- a/charts/vault/templates/vault-role.yaml
+++ b/charts/vault/templates/vault-role.yaml
@@ -1,11 +1,14 @@
-{{- if .Values.plugins.vaultPluginSecretsKubernetesReader.clusterScope }}
-kind: ClusterRole
+{{- range $ns := .Values.plugins.vaultPluginSecretsKubernetesReader.namespaces }}
+kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: vault-secrets-manager
+  namespace: "{{ $ns }}"
 rules:
 - apiGroups: [""]
   resources:
   - secrets
   verbs: ["get"]
+---
 {{- end }}
+


### PR DESCRIPTION
This PR avoids using ClusterRole if clusterScope value is false in Vault helm. 