### PR TITLE
Sort protos for documentation

### DIFF
--- a/site/Makefile
+++ b/site/Makefile
@@ -8,7 +8,7 @@ CONNECTORS_PROTO := $(ROOT_DIR)/pkg/connectors/protos
 .PHONY: generate
 generate: $(TOOLBIN)/crdoc $(TOOLBIN)/protoc $(TOOLBIN)/protoc-gen-doc
 	PATH=$(TOOLBIN) crdoc --template ./templates/crd/main.tmpl --resources $(ROOT_DIR)/charts/fybrik-crd/templates --output ./docs/reference/crds.md
-	PATH=$(TOOLBIN) protoc -I=$(CONNECTORS_PROTO) --doc_out=./docs/reference/ --doc_opt=./templates/proto/protoc.tmpl,connectors.md $(wildcard ./$(CONNECTORS_PROTO)/*.proto)
+	PATH=$(TOOLBIN) protoc -I=$(CONNECTORS_PROTO) --doc_out=./docs/reference/ --doc_opt=./templates/proto/protoc.tmpl,connectors.md $(sort $(wildcard ./$(CONNECTORS_PROTO)/*.proto))
 	go mod tidy
 
 .PHONY: run


### PR DESCRIPTION
Signed-off-by: Shlomit Koyfman <shlomitk@il.ibm.com>

`make -C site generate` generates a file named connectors.md. The order of the proto files sent as an input to protoc is not deterministic (platform dependent?), which may generate a file different from that of the master repository.

This PR makes the generation process deterministic.