### PR TITLE
A manifest was not updated properly

### DIFF
--- a/charts/fybrik-crd/templates/app.fybrik.io_fybrikmodules.yaml
+++ b/charts/fybrik-crd/templates/app.fybrik.io_fybrikmodules.yaml
@@ -292,6 +292,8 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
Signed-off-by: Shlomit Koyfman <shlomitk@il.ibm.com>

'make manifests' generates a modified manifest which should have been committed together with the changes in the FybrikModule types.