### PR TITLE
Plotter status fields should not be required

### DIFF
--- a/charts/fybrik-crd/templates/app.fybrik.io_blueprints.yaml
+++ b/charts/fybrik-crd/templates/app.fybrik.io_blueprints.yaml
@@ -473,8 +473,6 @@ spec:
                   each release should be mapped to the latest blueprint version or
                   be uninstalled.
                 type: object
-            required:
-            - modules
             type: object
         type: object
     served: true

--- a/charts/fybrik-crd/templates/app.fybrik.io_plotters.yaml
+++ b/charts/fybrik-crd/templates/app.fybrik.io_plotters.yaml
@@ -546,8 +546,6 @@ spec:
                             reconcile, each release should be mapped to the latest
                             blueprint version or be uninstalled.
                           type: object
-                      required:
-                      - modules
                       type: object
                   required:
                   - name

--- a/manager/apis/app/v1alpha1/blueprint_types.go
+++ b/manager/apis/app/v1alpha1/blueprint_types.go
@@ -138,8 +138,8 @@ type BlueprintStatus struct {
 
 	// ModulesState is a map which holds the status of each module
 	// its key is the instance name which is the unique name for the deployed instance related to this workload
-	// +required
-	ModulesState map[string]ObservedState `json:"modules"`
+	// +optional
+	ModulesState map[string]ObservedState `json:"modules,omitempty"`
 
 	// Releases map each release to the observed generation of the blueprint containing this release.
 	// At the end of reconcile, each release should be mapped to the latest blueprint version or be uninstalled.


### PR DESCRIPTION
Signed-off-by: Shlomit Koyfman <shlomitk@il.ibm.com>

Fixes https://github.com/fybrik/fybrik/issues/976

This PR no longer requires status.modules field in the plotter status.