### PR TITLE
Change ClusterManager implementations to local package visability

### DIFF
--- a/manager/controllers/app/fybrikapplication_controller.go
+++ b/manager/controllers/app/fybrikapplication_controller.go
@@ -447,7 +447,7 @@ func (r *FybrikApplicationReconciler) GetWorkloadCluster(application *api.Fybrik
 		}
 		// the workload runs in a local cluster
 		r.Log.V(0).Info("selector.clusterName field is not specified for an existing workload - a local cluster is assumed")
-		localClusterManager, err := local.NewManager(r.Client, utils.GetSystemNamespace())
+		localClusterManager, err := local.NewClusterManager(r.Client, utils.GetSystemNamespace())
 		if err != nil {
 			return multicluster.Cluster{}, err
 		}

--- a/manager/controllers/app/plotter_controller_unit_test.go
+++ b/manager/controllers/app/plotter_controller_unit_test.go
@@ -59,9 +59,9 @@ func TestPlotterController(t *testing.T) {
 	s := utils.NewScheme(g)
 	// Create a fake client to mock API calls.
 	cl := fake.NewFakeClientWithScheme(s, objs...)
-	dummyManager := &dummy.ClusterManager{
-		DeployedBlueprints: make(map[string]*app.Blueprint),
-		Clusters: []multicluster.Cluster{{
+	dummyManager := dummy.NewDummyClusterManager(
+		make(map[string]*app.Blueprint),
+		[]multicluster.Cluster{{
 			Name: "thegreendragon",
 			Metadata: struct {
 				Region        string
@@ -71,15 +71,14 @@ func TestPlotterController(t *testing.T) {
 				Region:        "theshire",
 				Zone:          "hobbiton",
 				VaultAuthPath: "kubernetes",
-			}}},
-	}
+			}}})
 
 	// Create a PlotterReconciler object with the scheme and fake client.
 	r := &PlotterReconciler{
 		Client:         cl,
 		Log:            ctrl.Log.WithName("test-controller"),
 		Scheme:         s,
-		ClusterManager: dummyManager,
+		ClusterManager: &dummyManager,
 	}
 
 	// Mock request to simulate Reconcile() being called on an event for a

--- a/manager/controllers/app/suite_test.go
+++ b/manager/controllers/app/suite_test.go
@@ -122,7 +122,7 @@ var _ = BeforeSuite(func(done Done) {
 		Expect(err).ToNot(HaveOccurred())
 
 		// Setup plotter controller
-		clusterMgr, err := local.NewManager(mgr.GetClient(), controllerNamespace)
+		clusterMgr, err := local.NewClusterManager(mgr.GetClient(), controllerNamespace)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(clusterMgr).NotTo(BeNil())
 		err = NewPlotterReconciler(mgr, "Plotter", clusterMgr).SetupWithManager(mgr)

--- a/manager/main.go
+++ b/manager/main.go
@@ -280,18 +280,18 @@ func newClusterManager(mgr manager.Manager) (multicluster.ClusterManager, error)
 		password := strings.TrimSpace(os.Getenv("RAZEE_PASSWORD"))
 
 		setupLog.Info("Using razee local at " + razeeURL)
-		return razee.NewRazeeLocalManager(strings.TrimSpace(razeeURL), strings.TrimSpace(user), password, multiClusterGroup)
+		return razee.NewRazeeLocalClusterManager(strings.TrimSpace(razeeURL), strings.TrimSpace(user), password, multiClusterGroup)
 	} else if apiKey, satConf := os.LookupEnv("IAM_API_KEY"); satConf {
 		setupLog.Info("Using IBM Satellite config")
-		return razee.NewSatConfManager(strings.TrimSpace(apiKey), multiClusterGroup)
+		return razee.NewSatConfClusterManager(strings.TrimSpace(apiKey), multiClusterGroup)
 	} else if apiKey, razeeOauth := os.LookupEnv("API_KEY"); razeeOauth {
 		setupLog.Info("Using Razee oauth")
 
 		razeeURL := strings.TrimSpace(os.Getenv("RAZEE_URL"))
-		return razee.NewRazeeOAuthManager(strings.TrimSpace(razeeURL), strings.TrimSpace(apiKey), multiClusterGroup)
+		return razee.NewRazeeOAuthClusterManager(strings.TrimSpace(razeeURL), strings.TrimSpace(apiKey), multiClusterGroup)
 	} else {
 		setupLog.Info("Using local cluster manager")
-		return local.NewManager(mgr.GetClient(), utils.GetSystemNamespace())
+		return local.NewClusterManager(mgr.GetClient(), utils.GetSystemNamespace())
 	}
 }
 

--- a/pkg/multicluster/dummy/dummy_manager.go
+++ b/pkg/multicluster/dummy/dummy_manager.go
@@ -10,13 +10,20 @@ import (
 	"fybrik.io/fybrik/pkg/multicluster"
 )
 
-// This ClusterManager is meant to be used for testing
-type ClusterManager struct {
+// MockClusterManager is meant to be used for testing
+type MockClusterManager struct {
 	DeployedBlueprints map[string]*v1alpha1.Blueprint
 	Clusters           []multicluster.Cluster
 }
 
-func (m *ClusterManager) GetClusters() ([]multicluster.Cluster, error) {
+func NewDummyClusterManager(blueprints map[string]*v1alpha1.Blueprint, clusters []multicluster.Cluster) MockClusterManager {
+	return MockClusterManager{
+		DeployedBlueprints: blueprints,
+		Clusters:           clusters,
+	}
+}
+
+func (m *MockClusterManager) GetClusters() ([]multicluster.Cluster, error) {
 	if m.Clusters != nil {
 		return m.Clusters, nil
 	}
@@ -28,7 +35,7 @@ func (m *ClusterManager) GetClusters() ([]multicluster.Cluster, error) {
 	}, nil
 }
 
-func (m *ClusterManager) GetBlueprint(cluster string, namespace string, name string) (*v1alpha1.Blueprint, error) {
+func (m *MockClusterManager) GetBlueprint(cluster string, namespace string, name string) (*v1alpha1.Blueprint, error) {
 	blueprint, found := m.DeployedBlueprints[cluster]
 	if found {
 		return blueprint, nil
@@ -36,17 +43,17 @@ func (m *ClusterManager) GetBlueprint(cluster string, namespace string, name str
 	return nil, errors.New("blueprint not found")
 }
 
-func (m *ClusterManager) CreateBlueprint(cluster string, blueprint *v1alpha1.Blueprint) error {
+func (m *MockClusterManager) CreateBlueprint(cluster string, blueprint *v1alpha1.Blueprint) error {
 	m.DeployedBlueprints[cluster] = blueprint
 	return nil
 }
 
-func (m *ClusterManager) UpdateBlueprint(cluster string, blueprint *v1alpha1.Blueprint) error {
+func (m *MockClusterManager) UpdateBlueprint(cluster string, blueprint *v1alpha1.Blueprint) error {
 	m.DeployedBlueprints[cluster] = blueprint
 	return nil
 }
 
-func (m *ClusterManager) DeleteBlueprint(cluster string, namespace string, name string) error {
+func (m *MockClusterManager) DeleteBlueprint(cluster string, namespace string, name string) error {
 	delete(m.DeployedBlueprints, cluster)
 	return nil
 }

--- a/pkg/multicluster/dummy/dummy_manager_test.go
+++ b/pkg/multicluster/dummy/dummy_manager_test.go
@@ -7,13 +7,14 @@ import (
 	"errors"
 	"testing"
 
-	app "fybrik.io/fybrik/manager/apis/app/v1alpha1"
-	"fybrik.io/fybrik/pkg/multicluster"
 	"github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	app "fybrik.io/fybrik/manager/apis/app/v1alpha1"
+	"fybrik.io/fybrik/pkg/multicluster"
 )
 
-var _ multicluster.ClusterManager = &ClusterManager{}
+var _ multicluster.ClusterManager = &MockClusterManager{}
 
 func TestDummyMultiClusterManager(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
@@ -23,7 +24,7 @@ func TestDummyMultiClusterManager(t *testing.T) {
 			Namespace: "ns",
 		},
 	}
-	manager := ClusterManager{
+	manager := MockClusterManager{
 		DeployedBlueprints: make(map[string]*app.Blueprint),
 	}
 

--- a/pkg/multicluster/local/local_cluster_manager.go
+++ b/pkg/multicluster/local/local_cluster_manager.go
@@ -8,49 +8,42 @@ import (
 	"fmt"
 
 	"emperror.dev/errors"
-	"fybrik.io/fybrik/manager/apis/app/v1alpha1"
-	"fybrik.io/fybrik/pkg/multicluster"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"fybrik.io/fybrik/manager/apis/app/v1alpha1"
+	"fybrik.io/fybrik/pkg/multicluster"
 )
 
 const (
 	clusterMetadataConfigmapName string = "cluster-metadata"
 )
 
-// ClusterManager for local cluster configuration
-type ClusterManager struct {
+// localClusterManager for local cluster configuration
+type localClusterManager struct {
 	Client    client.Client
 	Namespace string
 }
 
 // GetClusters returns a list of registered clusters
-func (cm *ClusterManager) GetClusters() ([]multicluster.Cluster, error) {
-	clusterMetadataConfigmap := corev1.ConfigMap{}
+func (cm *localClusterManager) GetClusters() ([]multicluster.Cluster, error) {
+	cmcm := corev1.ConfigMap{}
 	namespacedName := client.ObjectKey{
 		Name:      clusterMetadataConfigmapName,
 		Namespace: cm.Namespace,
 	}
-	if err := cm.Client.Get(context.Background(), namespacedName, &clusterMetadataConfigmap); err != nil {
+	if err := cm.Client.Get(context.Background(), namespacedName, &cmcm); err != nil {
 		return nil, errors.Wrap(err, "error in GetClusters")
 	}
-	var clusters []multicluster.Cluster
-	cluster := multicluster.Cluster{
-		Name: clusterMetadataConfigmap.Data["ClusterName"],
-		Metadata: multicluster.ClusterMetadata{
-			Region:        clusterMetadataConfigmap.Data["Region"],
-			Zone:          clusterMetadataConfigmap.Data["Zone"],
-			VaultAuthPath: clusterMetadataConfigmap.Data["VaultAuthPath"],
-		},
-	}
-	clusters = append(clusters, cluster)
+	cluster := multicluster.CreateCluster(cmcm)
+	clusters := []multicluster.Cluster{cluster}
 	return clusters, nil
 }
 
 // GetLocalClusterName returns the local cluster name
-func (cm *ClusterManager) GetLocalClusterName() (string, error) {
+func (cm *localClusterManager) GetLocalClusterName() (string, error) {
 	clusters, err := cm.GetClusters()
 	if err != nil {
 		return "", err
@@ -62,7 +55,7 @@ func (cm *ClusterManager) GetLocalClusterName() (string, error) {
 }
 
 // GetBlueprint returns a blueprint matching the given name, namespace and cluster details
-func (cm *ClusterManager) GetBlueprint(cluster string, namespace string, name string) (*v1alpha1.Blueprint, error) {
+func (cm *localClusterManager) GetBlueprint(cluster string, namespace string, name string) (*v1alpha1.Blueprint, error) {
 	if localCluster, err := cm.GetLocalClusterName(); err != nil || localCluster != cluster {
 		return nil, fmt.Errorf("unregistered cluster: %s", cluster)
 	}
@@ -77,12 +70,12 @@ func (cm *ClusterManager) GetBlueprint(cluster string, namespace string, name st
 }
 
 // CreateBlueprint creates a blueprint resource or updates an existing one
-func (cm *ClusterManager) CreateBlueprint(cluster string, blueprint *v1alpha1.Blueprint) error {
+func (cm *localClusterManager) CreateBlueprint(cluster string, blueprint *v1alpha1.Blueprint) error {
 	return cm.UpdateBlueprint(cluster, blueprint)
 }
 
-// UpdateBlueprint updates the given blueprint or creates a new one if does not exist
-func (cm *ClusterManager) UpdateBlueprint(cluster string, blueprint *v1alpha1.Blueprint) error {
+// UpdateBlueprint updates the given blueprint or creates a new one if it does not exist
+func (cm *localClusterManager) UpdateBlueprint(cluster string, blueprint *v1alpha1.Blueprint) error {
 	if localCluster, err := cm.GetLocalClusterName(); err != nil || localCluster != cluster {
 		return fmt.Errorf("unregistered cluster: %s", cluster)
 	}
@@ -103,7 +96,7 @@ func (cm *ClusterManager) UpdateBlueprint(cluster string, blueprint *v1alpha1.Bl
 }
 
 // DeleteBlueprint deletes the blueprint resource
-func (cm *ClusterManager) DeleteBlueprint(cluster string, namespace string, name string) error {
+func (cm *localClusterManager) DeleteBlueprint(cluster string, namespace string, name string) error {
 	blueprint, err := cm.GetBlueprint(cluster, namespace, name)
 	if err != nil {
 		return err
@@ -111,9 +104,9 @@ func (cm *ClusterManager) DeleteBlueprint(cluster string, namespace string, name
 	return cm.Client.Delete(context.Background(), blueprint)
 }
 
-// NewManager creates a new ClusterManager for a local cluster configuration
-func NewManager(client client.Client, namespace string) (multicluster.ClusterManager, error) {
-	return &ClusterManager{
+// NewClusterManager creates an instance of ClusterManager for a local cluster configuration
+func NewClusterManager(client client.Client, namespace string) (multicluster.ClusterManager, error) {
+	return &localClusterManager{
 		Client:    client,
 		Namespace: namespace,
 	}, nil

--- a/pkg/multicluster/local/local_cluster_manager_test.go
+++ b/pkg/multicluster/local/local_cluster_manager_test.go
@@ -6,16 +6,17 @@ package local
 import (
 	"testing"
 
-	"fybrik.io/fybrik/pkg/multicluster"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"fybrik.io/fybrik/pkg/multicluster"
 )
 
-var _ multicluster.ClusterManager = &ClusterManager{}
+var _ multicluster.ClusterManager = &localClusterManager{}
 
 func TestLocalClusterManager(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
@@ -35,7 +36,7 @@ func TestLocalClusterManager(t *testing.T) {
 	}
 	cl := fake.NewFakeClientWithScheme(s, objs...)
 	namespace := "fybrik-system"
-	cm, err := NewManager(cl, namespace)
+	cm, err := NewClusterManager(cl, namespace)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	g.Expect(cm).NotTo(gomega.BeNil())
 	var actualClusters []multicluster.Cluster

--- a/pkg/multicluster/multi_cluster_manager.go
+++ b/pkg/multicluster/multi_cluster_manager.go
@@ -4,9 +4,11 @@
 package multicluster
 
 import (
-	"fybrik.io/fybrik/manager/apis/app/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+
+	"fybrik.io/fybrik/manager/apis/app/v1alpha1"
 )
 
 type ClusterLister interface {
@@ -30,6 +32,18 @@ type ClusterMetadata struct {
 type Cluster struct {
 	Name     string
 	Metadata ClusterMetadata
+}
+
+func CreateCluster(cm corev1.ConfigMap) Cluster {
+	cluster := Cluster{
+		Name: cm.Data["ClusterName"],
+		Metadata: ClusterMetadata{
+			Region:        cm.Data["Region"],
+			Zone:          cm.Data["Zone"],
+			VaultAuthPath: cm.Data["VaultAuthPath"],
+		},
+	}
+	return cluster
 }
 
 // Decode json into runtime.Object, which is a pointer (such as &corev1.ConfigMapList)

--- a/pkg/multicluster/razee/razee_cluster_manager.go
+++ b/pkg/multicluster/razee/razee_cluster_manager.go
@@ -5,28 +5,32 @@ package razee
 
 import (
 	"fmt"
+	corev1 "k8s.io/api/core/v1"
 	"strconv"
 	"strings"
 
 	"emperror.dev/errors"
-	"github.com/IBM/satcon-client-go/client/types"
-
-	"fybrik.io/fybrik/manager/apis/app/v1alpha1"
-	"fybrik.io/fybrik/pkg/multicluster"
 	"github.com/IBM/satcon-client-go/client"
 	"github.com/IBM/satcon-client-go/client/auth/apikey"
 	"github.com/IBM/satcon-client-go/client/auth/iam"
 	"github.com/IBM/satcon-client-go/client/auth/local"
+	"github.com/IBM/satcon-client-go/client/types"
 	"github.com/ghodss/yaml"
 	"github.com/go-logr/logr"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+
+	"fybrik.io/fybrik/manager/apis/app/v1alpha1"
+	"fybrik.io/fybrik/pkg/multicluster"
 )
 
 const (
-	clusterMetadataConfigMapSL string = "/api/v1/namespaces/fybrik-system/configmaps/cluster-metadata"
+	clusterMetadataConfigMapSL = "/api/v1/namespaces/fybrik-system/configmaps/cluster-metadata"
+	endPointURL                = "https://config.satellite.cloud.ibm.com/graphql"
+	bluePrintSelfLink          = "/apis/app.fybrik.io/v1alpha1/namespaces/%s/blueprints/%s"
+	channelNameTemplate        = "fybrik.io-%s-%s"
+	groupNameTemplate          = "fybrik-%s"
 )
 
 var (
@@ -37,14 +41,14 @@ func init() {
 	_ = v1alpha1.AddToScheme(scheme)
 }
 
-type ClusterManager struct {
+type razeeClusterManager struct {
 	orgID        string
 	clusterGroup string
 	con          client.SatCon
 	log          logr.Logger
 }
 
-func (r *ClusterManager) GetClusters() ([]multicluster.Cluster, error) {
+func (r *razeeClusterManager) GetClusters() ([]multicluster.Cluster, error) {
 	var clusters []multicluster.Cluster
 	var razeeClusters []types.Cluster
 	var err error
@@ -76,29 +80,22 @@ func (r *ClusterManager) GetClusters() ([]multicluster.Cluster, error) {
 			continue
 		}
 		scheme := runtime.NewScheme()
-		clusterMetadataConfigmap := v1.ConfigMap{}
-		err = multicluster.Decode(resourceContent.Content, scheme, &clusterMetadataConfigmap)
+		cmcm := corev1.ConfigMap{}
+		err = multicluster.Decode(resourceContent.Content, scheme, &cmcm)
 		if err != nil {
 			return nil, err
 		}
-		cluster := multicluster.Cluster{
-			Name: clusterMetadataConfigmap.Data["ClusterName"],
-			Metadata: multicluster.ClusterMetadata{
-				Region:        clusterMetadataConfigmap.Data["Region"],
-				Zone:          clusterMetadataConfigmap.Data["Zone"],
-				VaultAuthPath: clusterMetadataConfigmap.Data["VaultAuthPath"],
-			},
-		}
+		cluster := multicluster.CreateCluster(cmcm)
 		clusters = append(clusters, cluster)
 	}
 	return clusters, nil
 }
 
 func createBluePrintSelfLink(namespace string, name string) string {
-	return fmt.Sprintf("/apis/app.fybrik.io/v1alpha1/namespaces/%s/blueprints/%s", namespace, name)
+	return fmt.Sprintf(bluePrintSelfLink, namespace, name)
 }
 
-func (r *ClusterManager) GetBlueprint(clusterName string, namespace string, name string) (*v1alpha1.Blueprint, error) {
+func (r *razeeClusterManager) GetBlueprint(clusterName string, namespace string, name string) (*v1alpha1.Blueprint, error) {
 	selfLink := createBluePrintSelfLink(namespace, name)
 	cluster, err := r.con.Clusters.ClusterByName(r.orgID, clusterName)
 	if err != nil {
@@ -131,7 +128,7 @@ func (r *ClusterManager) GetBlueprint(clusterName string, namespace string, name
 }
 
 func getGroupName(cluster string) string {
-	return "fybrik-" + cluster
+	return fmt.Sprintf(groupNameTemplate, cluster)
 }
 
 type Collection struct {
@@ -140,7 +137,7 @@ type Collection struct {
 	Items           []metav1.Object `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-func (r *ClusterManager) CreateBlueprint(cluster string, blueprint *v1alpha1.Blueprint) error {
+func (r *razeeClusterManager) CreateBlueprint(cluster string, blueprint *v1alpha1.Blueprint) error {
 	groupName := getGroupName(cluster)
 	channelName := channelName(cluster, blueprint.Name)
 	version := "0"
@@ -242,7 +239,7 @@ func (r *ClusterManager) CreateBlueprint(cluster string, blueprint *v1alpha1.Blu
 	return nil
 }
 
-func (r *ClusterManager) UpdateBlueprint(cluster string, blueprint *v1alpha1.Blueprint) error {
+func (r *razeeClusterManager) UpdateBlueprint(cluster string, blueprint *v1alpha1.Blueprint) error {
 	channelName := channelName(cluster, blueprint.Name)
 
 	content, err := yaml.Marshal(blueprint)
@@ -295,7 +292,7 @@ func (r *ClusterManager) UpdateBlueprint(cluster string, blueprint *v1alpha1.Blu
 	return nil
 }
 
-func (r *ClusterManager) DeleteBlueprint(cluster string, namespace string, name string) error {
+func (r *razeeClusterManager) DeleteBlueprint(cluster string, namespace string, name string) error {
 	channelName := channelName(cluster, name)
 	channel, err := r.con.Channels.ChannelByName(r.orgID, channelName)
 	if err != nil {
@@ -330,13 +327,14 @@ func (r *ClusterManager) DeleteBlueprint(cluster string, namespace string, name 
 	return nil
 }
 
-// The channel name should be per cluster and plotter so it cannot be based on
+// The channel name should be per cluster and plotter, so it cannot be based on
 // the namespace that is random for every blueprint
 func channelName(cluster string, name string) string {
-	return "fybrik.io" + "-" + cluster + "-" + name
+	return fmt.Sprintf(channelNameTemplate, cluster, name)
 }
 
-func NewRazeeLocalManager(url string, login string, password string, clusterGroup string) (multicluster.ClusterManager, error) {
+// NewRazeeLocalClusterManager creates an instance of Razee based ClusterManager with userName/password authentication
+func NewRazeeLocalClusterManager(url string, login string, password string, clusterGroup string) (multicluster.ClusterManager, error) {
 	localAuth, err := local.NewClient(url, login, password)
 	if err != nil {
 		return nil, err
@@ -354,7 +352,7 @@ func NewRazeeLocalManager(url string, login string, password string, clusterGrou
 
 	logger.Info("Initializing Razee local", "orgId", me.OrgId, "clusterGroup", clusterGroup)
 
-	return &ClusterManager{
+	return &razeeClusterManager{
 		orgID:        me.OrgId,
 		clusterGroup: clusterGroup,
 		con:          con,
@@ -362,7 +360,8 @@ func NewRazeeLocalManager(url string, login string, password string, clusterGrou
 	}, nil
 }
 
-func NewRazeeOAuthManager(url string, apiKey string, clusterGroup string) (multicluster.ClusterManager, error) {
+// NewRazeeOAuthClusterManager creates an instance of Razee based ClusterManager with OAuth authentication
+func NewRazeeOAuthClusterManager(url string, apiKey string, clusterGroup string) (multicluster.ClusterManager, error) {
 	auth, err := apikey.NewClient(apiKey)
 	if err != nil {
 		return nil, err
@@ -380,7 +379,7 @@ func NewRazeeOAuthManager(url string, apiKey string, clusterGroup string) (multi
 
 	logger.Info("Initializing Razee using oauth", "orgId", me.OrgId, "clusterGroup", clusterGroup)
 
-	return &ClusterManager{
+	return &razeeClusterManager{
 		orgID:        me.OrgId,
 		clusterGroup: clusterGroup,
 		con:          con,
@@ -388,7 +387,8 @@ func NewRazeeOAuthManager(url string, apiKey string, clusterGroup string) (multi
 	}, nil
 }
 
-func NewSatConfManager(apikey string, clusterGroup string) (multicluster.ClusterManager, error) {
+// NewSatConfClusterManager creates an instance of Razee based ClusterManager with Satellite authentication
+func NewSatConfClusterManager(apikey string, clusterGroup string) (multicluster.ClusterManager, error) {
 	iamClient, err := iam.NewIAMClient(apikey, "")
 	if err != nil {
 		return nil, err
@@ -396,7 +396,10 @@ func NewSatConfManager(apikey string, clusterGroup string) (multicluster.Cluster
 	if iamClient == nil {
 		return nil, errors.New("the IAMClient returned nil for IBM Cloud Satellite Config")
 	}
-	con, _ := client.New("https://config.satellite.cloud.ibm.com/graphql", iamClient.Client)
+	con, err := client.New(endPointURL, iamClient.Client)
+	if err != nil {
+		return nil, err
+	}
 
 	me, err := con.Users.Me()
 	if err != nil {
@@ -411,7 +414,7 @@ func NewSatConfManager(apikey string, clusterGroup string) (multicluster.Cluster
 
 	logger.Info("Initializing Razee with IBM Satellite Config", "orgId", me.OrgId, "clusterGroup", clusterGroup)
 
-	return &ClusterManager{
+	return &razeeClusterManager{
 		orgID:        me.OrgId,
 		clusterGroup: clusterGroup,
 		con:          con,


### PR DESCRIPTION
- Rename ClusterManager implementation constructs to explicit implementation names

with package visibility, e.g. for Razee from ClusterManager to razeeCluaterManager. Add methods to create different ClusterMnager implementations, NewXXXClusterManager.

- Add a method to create a cluster from ConfigMap. (it's used by several ClusterManager implementations)

- Add several constants

- Fix order of imports

/fixes #988

Signed-off-by: Alexey Roytman <roytman@il.ibm.com>