### PR TITLE
Refers to #793. Add ModulesNamespace to Blueprint spec

### DIFF
--- a/charts/fybrik-crd/templates/app.fybrik.io_blueprints.yaml
+++ b/charts/fybrik-crd/templates/app.fybrik.io_blueprints.yaml
@@ -416,9 +416,14 @@ spec:
                   InstanceName which is the unique name for the deployed instance
                   related to this workload
                 type: object
+              modulesNamespace:
+                description: ModulesNamespace is the namespace where modules should
+                  be allocated
+                type: string
             required:
             - cluster
             - modules
+            - modulesNamespace
             type: object
           status:
             description: BlueprintStatus defines the observed state of Blueprint This

--- a/charts/fybrik-crd/templates/app.fybrik.io_plotters.yaml
+++ b/charts/fybrik-crd/templates/app.fybrik.io_plotters.yaml
@@ -376,6 +376,10 @@ spec:
                   - subFlows
                   type: object
                 type: array
+              modulesNamespace:
+                description: ModulesNamespace is the namespace where modules should
+                  be allocated
+                type: string
               templates:
                 additionalProperties:
                   description: Template contains basic information about the required
@@ -452,6 +456,7 @@ spec:
             required:
             - assets
             - flows
+            - modulesNamespace
             - templates
             type: object
           status:

--- a/manager/apis/app/v1alpha1/blueprint_types.go
+++ b/manager/apis/app/v1alpha1/blueprint_types.go
@@ -116,6 +116,10 @@ type BlueprintSpec struct {
 	// +required
 	Cluster string `json:"cluster"`
 
+	// ModulesNamespace is the namespace where modules should be allocated
+	// +required
+	ModulesNamespace string `json:"modulesNamespace"`
+
 	// Modules is a map which contains modules that indicate the data path components that run in this cluster
 	// The map key is InstanceName which is the unique name for the deployed instance related to this workload
 	// +required

--- a/manager/apis/app/v1alpha1/plotter_types.go
+++ b/manager/apis/app/v1alpha1/plotter_types.go
@@ -217,6 +217,10 @@ type PlotterSpec struct {
 	// +required
 	Flows []Flow `json:"flows"`
 
+	// ModulesNamespace is the namespace where modules should be allocated
+	// +required
+	ModulesNamespace string `json:"modulesNamespace"`
+
 	// Templates is a map holding the templates used in this plotter steps
 	// The key is the template name
 	// +required

--- a/manager/controllers/app/blueprint_controller.go
+++ b/manager/controllers/app/blueprint_controller.go
@@ -132,7 +132,7 @@ func (r *BlueprintReconciler) deleteExternalResources(blueprint *app.Blueprint) 
 
 func (r *BlueprintReconciler) applyChartResource(log logr.Logger, chartSpec app.ChartSpec, args map[string]interface{}, blueprint *app.Blueprint, releaseName string) (ctrl.Result, error) {
 	log.Info(fmt.Sprintf("--- Chart Ref ---\n\n%v\n\n", chartSpec.Name))
-	kubeNamespace := utils.GetDefaultModulesNamespace()
+	kubeNamespace := blueprint.Spec.ModulesNamespace
 
 	args = CopyMap(args)
 	for k, v := range chartSpec.Values {
@@ -211,7 +211,7 @@ func (r *BlueprintReconciler) updateModuleState(blueprint *app.Blueprint, instan
 }
 
 func (r *BlueprintReconciler) reconcile(ctx context.Context, log logr.Logger, blueprint *app.Blueprint) (ctrl.Result, error) {
-	modulesNamespace := utils.GetDefaultModulesNamespace()
+	modulesNamespace := blueprint.Spec.ModulesNamespace
 	// Gather all templates and process them into a list of resources to apply
 	// force-update if the blueprint spec is different
 	updateRequired := blueprint.Status.ObservedGeneration != blueprint.GetGeneration()

--- a/manager/controllers/app/blueprint_mgr.go
+++ b/manager/controllers/app/blueprint_mgr.go
@@ -73,6 +73,8 @@ func (r *PlotterReconciler) GenerateBlueprint(instances []ModuleInstanceSpec, cl
 
 	spec.Cluster = clusterName
 
+	spec.ModulesNamespace = utils.GetDefaultModulesNamespace()
+
 	// Create the map that contains BlueprintModules
 
 	var blueprintModules = make(map[string]app.BlueprintModule)

--- a/manager/controllers/app/blueprint_mgr.go
+++ b/manager/controllers/app/blueprint_mgr.go
@@ -50,7 +50,7 @@ func (r *PlotterReconciler) RefineInstances(instances []ModuleInstanceSpec) []Mo
 }
 
 // GenerateBlueprints creates Blueprint specs (one per cluster)
-func (r *PlotterReconciler) GenerateBlueprints(instances []ModuleInstanceSpec) map[string]app.BlueprintSpec {
+func (r *PlotterReconciler) GenerateBlueprints(instances []ModuleInstanceSpec, plotter *app.Plotter) map[string]app.BlueprintSpec {
 	blueprintMap := make(map[string]app.BlueprintSpec)
 	instanceMap := make(map[string][]ModuleInstanceSpec)
 	for _, moduleInstance := range instances {
@@ -59,7 +59,7 @@ func (r *PlotterReconciler) GenerateBlueprints(instances []ModuleInstanceSpec) m
 	for key, instanceList := range instanceMap {
 		// unite several instances of a read/write module
 		instances := r.RefineInstances(instanceList)
-		blueprintMap[key] = r.GenerateBlueprint(instances, key)
+		blueprintMap[key] = r.GenerateBlueprint(instances, key, plotter)
 	}
 	utils.PrintStructure(blueprintMap, r.Log, "BlueprintMap")
 	return blueprintMap
@@ -68,12 +68,12 @@ func (r *PlotterReconciler) GenerateBlueprints(instances []ModuleInstanceSpec) m
 // GenerateBlueprint creates the Blueprint spec based on the datasets and the governance actions required, which dictate the modules that must run in the fybrik
 // Credentials for accessing data set are stored in a credential management system (such as vault) and the paths for accessing them are included in the blueprint.
 // The credentials themselves are not included in the blueprint.
-func (r *PlotterReconciler) GenerateBlueprint(instances []ModuleInstanceSpec, clusterName string) app.BlueprintSpec {
+func (r *PlotterReconciler) GenerateBlueprint(instances []ModuleInstanceSpec, clusterName string, plotter *app.Plotter) app.BlueprintSpec {
 	var spec app.BlueprintSpec
 
 	spec.Cluster = clusterName
 
-	spec.ModulesNamespace = utils.GetDefaultModulesNamespace()
+	spec.ModulesNamespace = plotter.Spec.ModulesNamespace
 
 	// Create the map that contains BlueprintModules
 

--- a/manager/controllers/app/fybrik_notebook_test.go
+++ b/manager/controllers/app/fybrik_notebook_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 
 	apiv1alpha1 "fybrik.io/fybrik/manager/apis/app/v1alpha1"
-	"fybrik.io/fybrik/manager/controllers/utils"
 	"fybrik.io/fybrik/pkg/test"
 	"github.com/apache/arrow/go/arrow"
 	"github.com/apache/arrow/go/arrow/array"
@@ -147,7 +146,7 @@ func TestS3Notebook(t *testing.T) {
 		return application.Status.Ready
 	}, timeout, interval).Should(gomega.Equal(true))
 
-	modulesNamespace := utils.GetDefaultModulesNamespace()
+	modulesNamespace := plotter.Spec.ModulesNamespace
 	fmt.Printf("data access module namespace notebook test: %s\n", modulesNamespace)
 
 	// Forward port of arrow flight service to local port

--- a/manager/controllers/app/fybrikapplication_controller.go
+++ b/manager/controllers/app/fybrikapplication_controller.go
@@ -631,10 +631,11 @@ func (r *FybrikApplicationReconciler) buildSolution(applicationContext *api.Fybr
 	}
 
 	plotterSpec := &api.PlotterSpec{
-		Selector:  applicationContext.Spec.Selector,
-		Assets:    map[string]api.AssetDetails{},
-		Flows:     []api.Flow{},
-		Templates: map[string]api.Template{},
+		Selector:         applicationContext.Spec.Selector,
+		Assets:           map[string]api.AssetDetails{},
+		Flows:            []api.Flow{},
+		ModulesNamespace: utils.GetDefaultModulesNamespace(),
+		Templates:        map[string]api.Template{},
 	}
 
 	for _, item := range requirements {

--- a/manager/controllers/app/fybrikapplication_controller_test.go
+++ b/manager/controllers/app/fybrikapplication_controller_test.go
@@ -139,7 +139,7 @@ var _ = Describe("FybrikApplication Controller", func() {
 			Eventually(func() error {
 				return k8sClient.Get(context.Background(), blueprintObjectKey, blueprint)
 			}, timeout, interval).Should(Succeed(), "Blueprint has not been created")
-			Expect(blueprint.Spec.ModulesNamespace).To(Equal("fybrik-blueprints"))
+			Expect(blueprint.Spec.ModulesNamespace).To(Equal(utils.GetDefaultModulesNamespace()))
 
 			for _, module := range blueprint.Spec.Modules {
 				Expect(module.Arguments.Labels["label1"]).To(Equal("foo"))

--- a/manager/controllers/app/fybrikapplication_controller_test.go
+++ b/manager/controllers/app/fybrikapplication_controller_test.go
@@ -139,6 +139,7 @@ var _ = Describe("FybrikApplication Controller", func() {
 			Eventually(func() error {
 				return k8sClient.Get(context.Background(), blueprintObjectKey, blueprint)
 			}, timeout, interval).Should(Succeed(), "Blueprint has not been created")
+			Expect(blueprint.Spec.ModulesNamespace).To(Equal("fybrik-blueprints"))
 
 			for _, module := range blueprint.Spec.Modules {
 				Expect(module.Arguments.Labels["label1"]).To(Equal("foo"))
@@ -156,7 +157,7 @@ var _ = Describe("FybrikApplication Controller", func() {
 			By("Status should contain the details of the endpoint")
 			Expect(len(application.Status.AssetStates)).To(Equal(1))
 			// TODO endpoint details are not set yet
-			fqdn := "test-app-e2e-default-read-module-test-e2e." + utils.GetDefaultModulesNamespace()
+			fqdn := "test-app-e2e-default-read-module-test-e2e." + blueprint.Spec.ModulesNamespace
 			Expect(application.Status.AssetStates["s3/redact-dataset"].Endpoint).To(Equal(apiv1alpha1.EndpointSpec{
 				Hostname: fqdn,
 				Port:     80,

--- a/manager/controllers/app/plotter_controller.go
+++ b/manager/controllers/app/plotter_controller.go
@@ -289,7 +289,7 @@ func (r *PlotterReconciler) getBlueprintsMap(plotter *app.Plotter) map[string]ap
 			}
 		}
 	}
-	blueprints := r.GenerateBlueprints(moduleInstances)
+	blueprints := r.GenerateBlueprints(moduleInstances, plotter)
 
 	return blueprints
 }

--- a/manager/testdata/blueprint-read.yaml
+++ b/manager/testdata/blueprint-read.yaml
@@ -13,6 +13,7 @@ spec:
     matchLabels:
       app: notebook
   cluster: cluster1
+  modulesNamespace: fybrik-blueprints
   modules:
     notebook-read-module:
       name: notebook-read-module
@@ -44,4 +45,3 @@ spec:
                 role: module
                 secretPath: "/v1/kubernetes-secrets/secret-name?namespace=default"
             format: parquet
-  modulesNamespace: fybrik-blueprints

--- a/manager/testdata/blueprint-read.yaml
+++ b/manager/testdata/blueprint-read.yaml
@@ -44,3 +44,4 @@ spec:
                 role: module
                 secretPath: "/v1/kubernetes-secrets/secret-name?namespace=default"
             format: parquet
+  modulesNamespace: fybrik-blueprints

--- a/manager/testdata/blueprint.yaml
+++ b/manager/testdata/blueprint.yaml
@@ -10,6 +10,7 @@ metadata:
     app.fybrik.io/app-name: notebook
 spec:
   cluster: cluster1
+  modulesNamespace: fybrik-blueprints
   modules:
     notebook-copy-batch:
       name: notebook-copy-batch
@@ -71,4 +72,3 @@ spec:
                 secretPath: "/v1/kubernetes-secrets/secret-name?namespace=default"
             format: parquet
           assetID: xyz
-  modulesNamespace: fybrik-blueprints

--- a/manager/testdata/blueprint.yaml
+++ b/manager/testdata/blueprint.yaml
@@ -71,3 +71,4 @@ spec:
                 secretPath: "/v1/kubernetes-secrets/secret-name?namespace=default"
             format: parquet
           assetID: xyz
+  modulesNamespace: fybrik-blueprints

--- a/site/docs/reference/crds.md
+++ b/site/docs/reference/crds.md
@@ -111,6 +111,13 @@ BlueprintSpec defines the desired state of Blueprint, which defines the componen
           Modules is a map which contains modules that indicate the data path components that run in this cluster The map key is InstanceName which is the unique name for the deployed instance related to this workload<br/>
         </td>
         <td>true</td>
+      </tr><tr>
+        <td><b>modulesNamespace</b></td>
+        <td>string</td>
+        <td>
+          ModulesNamespace is the namespace where modules should be allocated<br/>
+        </td>
+        <td>true</td>
       </tr></tbody>
 </table>
 
@@ -2428,6 +2435,13 @@ PlotterSpec defines the desired state of Plotter, which is applied in a multi-cl
         <td>[]object</td>
         <td>
           <br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>modulesNamespace</b></td>
+        <td>string</td>
+        <td>
+          ModulesNamespace is the namespace where modules should be allocated<br/>
         </td>
         <td>true</td>
       </tr><tr>


### PR DESCRIPTION
This PR adds a field ModulesNamespace to the Blueprint spec and uses it for helm chart installs.