### PR TITLE
Vault deployment related fixes.

### DIFF
--- a/charts/vault/templates/post-pod-creation-cm.yaml
+++ b/charts/vault/templates/post-pod-creation-cm.yaml
@@ -10,7 +10,7 @@ data:
 {{- if semverCompare "<1.21-0" .Capabilities.KubeVersion.Version }}
       vault write auth/kubernetes/config kubernetes_host="https://kubernetes.default.svc:443"
 {{- else }}
-      vault write auth/kubernetes/config issuer="https://kubernetes.default.svc.cluster.local" kubernetes_host="https://kubernetes.default.svc:443"
+      vault write auth/kubernetes/config issuer="https://kubernetes.default.svc" kubernetes_host="https://kubernetes.default.svc:443"
 {{- end }}
       # register and enable secret engine
       SHA256=$(sha256sum /usr/local/libexec/vault/vault-plugin-secrets-kubernetes-reader | cut -d ' ' -f1)

--- a/site/docs/get-started/quickstart.md
+++ b/site/docs/get-started/quickstart.md
@@ -63,7 +63,7 @@ helm install cert-manager jetstack/cert-manager \
 		cd fybrik
 		helm dependency update charts/vault
 		helm install vault charts/vault --create-namespace -n fybrik-system \
-			--set "global.openshift=true" \
+			--set "vault.global.openshift=true" \
 			--set "vault.injector.enabled=false" \
 			--set "vault.server.dev.enabled=true" \
 			--values charts/vault/env/dev/vault-single-cluster-values.yaml
@@ -87,7 +87,7 @@ Run the following to install vault and the plugin in development mode:
 
     ```bash
     helm install vault fybrik-charts/vault --create-namespace -n fybrik-system \
-        --set "global.openshift=true" \
+        --set "vault.global.openshift=true" \
         --set "vault.injector.enabled=false" \
         --set "vault.server.dev.enabled=true" \
         --values https://raw.githubusercontent.com/fybrik/fybrik/v0.4.0/charts/vault/env/dev/vault-single-cluster-values.yaml


### PR DESCRIPTION
This PR does the following:

1) removes `.cluster.local` suffix from the `issuer` field in Vault kubernetes auth method configuration. (https://www.vaultproject.io/docs/auth/kubernetes#discovering-the-service-account-issuer)
2) adds `vault.` prefix for openshift flag in vault helm deployment described in the quick-start.