### PR TITLE
Add helm version check

### DIFF
--- a/hack/tools/install_helm.sh
+++ b/hack/tools/install_helm.sh
@@ -5,14 +5,16 @@
 
 source ./common.sh
 
-header_text "Checking for bin/helm"
-[[ -f bin/helm ]] && exit 0
+DESIRED_VERSION=v3.6.3
 
-header_text "Installing bin/helm"
+header_text "Checking for bin/helm $DESIRED_VERSION"
+[[ -f bin/helm &&  `bin/helm version --template='{{.Version}}'` == $DESIRED_VERSION ]] && exit 0
+
+header_text "Installing bin/helm $DESIRED_VERSION"
 # Helm is currently fixed to 3.6.3 until the deployment process is migrated to 3.7.0 (https://github.com/helm/helm/releases/tag/v3.7.0)
 # Some used experimental OCI features have been removed.
 mkdir -p ./bin
 curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
 chmod 700 get_helm.sh
-HELM_INSTALL_DIR=bin DESIRED_VERSION=v3.6.3 ./get_helm.sh --no-sudo
+HELM_INSTALL_DIR=bin ./get_helm.sh -v $DESIRED_VERSION --no-sudo
 rm -rf get_helm.sh


### PR DESCRIPTION
There is no full backward compatibility between helm v3.6.3 and v3.7.x, therefore we have to guarantee that all developers work with the correct helm version. 

/fixes #1000
Signed-off-by: Alexey Roytman <roytman@il.ibm.com>