### PR TITLE
Avoid pushing fybrik-template chart to public registry.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,9 +215,9 @@ jobs:
       if: ${{ github.event_name != 'pull_request' }}
       env:
         DOCKER_PUBLIC_TAGNAME:  ${{ steps.version.outputs.version }}
-      run: make docker-retag-and-push-public && make helm-push-public
+      run: make docker-retag-and-push-public
     - name: Publish latest image tag on push tag event
       if: github.event_name != 'pull_request' && steps.version.outputs.push_tag_event == 'true'
       env:
         DOCKER_PUBLIC_TAGNAME: 'latest'
-      run: make docker-retag-and-push-public && make helm-push-public
+      run: make docker-retag-and-push-public

--- a/Makefile
+++ b/Makefile
@@ -118,10 +118,6 @@ endef
 docker-retag-and-push-public:
 	$(call do-docker-retag-and-push-public)
 
-.PHONY: helm-push-public
-helm-push-public:
-	DOCKER_HOSTNAME=${DOCKER_PUBLIC_HOSTNAME} DOCKER_NAMESPACE=${DOCKER_PUBLIC_NAMESPACE} DOCKER_TAGNAME=${DOCKER_PUBLIC_TAGNAME} make -C modules helm-chart-push
-
 .PHONY: save-images
 save-images:
 	docker save -o images.tar ${DOCKER_HOSTNAME}/${DOCKER_NAMESPACE}/manager:${DOCKER_TAGNAME} \


### PR DESCRIPTION
With the recent move of the implicit copy charts to the  [data-movement-operator](https://github.com/fybrik/data-movement-operator/tree/master/modules) repo only the fybrik-template chart is left as a chart we push into the public registry. As this chart is used for testing there is no point in pushing it to the public registry thus this PR removes the use of `helm-push-public`.