### PR TITLE
Fix gosec annotations

### DIFF
--- a/pkg/taxonomy/io/write.go
+++ b/pkg/taxonomy/io/write.go
@@ -26,7 +26,7 @@ func WriteDocumentToFile(doc *model.Document, outPath string) error {
 	if err != nil {
 		return err
 	}
-	/* #nosec G306 */
-	// Avoid nosec "Expect WriteFile permissions to be 0600 or less" error
+
+	// #nosec G306 -- Avoid nosec "Expect WriteFile permissions to be 0600 or less" error
 	return ioutil.WriteFile(filepath.Clean(outPath), encoded, 0644)
 }

--- a/pkg/test/portforward.go
+++ b/pkg/test/portforward.go
@@ -34,8 +34,7 @@ func StartCmdAndStreamOutput(cmd *exec.Cmd) (stdout, stderr io.ReadCloser, err e
 // runPortForward runs port-forward, warning, this may need root functionality on some systems.
 // The function was inspired from kubernetes e2e framework
 func RunPortForward(ns string, svcName string, port int) (string, error) {
-	/* #nosec G204 */
-	// Avoid "Subprocess launched with variable" error
+	// #nosec G204 -- Avoid "Subprocess launched with variable" error
 	cmd := exec.Command("kubectl", "-n", ns, "port-forward", "svc/"+svcName, ":"+strconv.Itoa(port))
 	// This is somewhat ugly but is the only way to retrieve the port that was picked
 	// by the port-forward command. We don't want to hard code the port as we have no


### PR DESCRIPTION
The format of gosec annotations was changed. (At least the original format is not recognized).
This PR updates the annotations. 

Signed-off-by: Alexey Roytman <roytman@il.ibm.com>