### PR TITLE
doc: add the link to the page of dashboard sample to navigation bar

### DIFF
--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -12,6 +12,7 @@ nav:
 - Get Started:
   - get-started/quickstart.md
   - samples/notebook.md
+  - samples/dashboard-sample.md
 - Concepts:
   - concepts/introduction.md
   - concepts/architecture.md


### PR DESCRIPTION
this add the link to the page of dashboard sample to navigation bar under "Get Started"

Fixes fybrik#1019

Signed-off-by: Hui Yu <ityuhui@gmail.com>