### PR TITLE
Fix for issue 1028

### DIFF
--- a/manager/controllers/app/blueprint_controller_test.go
+++ b/manager/controllers/app/blueprint_controller_test.go
@@ -24,7 +24,7 @@ func deployBlueprint(namespace string, shouldSucceed bool) {
 
 	// Set the correct namespace
 	blueprint.SetNamespace(namespace)
-	blueprint.Spec.ModulesNamespace = namespace
+	blueprint.Spec.ModulesNamespace = utils.GetDefaultModulesNamespace()
 	fmt.Printf("Blueprint controller unit test - blueprint namespace : %s\n", namespace)
 	blueprintKey := client.ObjectKeyFromObject(blueprint)
 

--- a/manager/controllers/app/blueprint_controller_test.go
+++ b/manager/controllers/app/blueprint_controller_test.go
@@ -24,7 +24,8 @@ func deployBlueprint(namespace string, shouldSucceed bool) {
 
 	// Set the correct namespace
 	blueprint.SetNamespace(namespace)
-	fmt.Printf("Blueprint controller unit test - blueprint namespace: %s\n", namespace)
+	blueprint.Spec.ModulesNamespace = namespace
+	fmt.Printf("Blueprint controller unit test - blueprint namespace : %s\n", namespace)
 	blueprintKey := client.ObjectKeyFromObject(blueprint)
 
 	// Create Blueprint

--- a/manager/controllers/app/blueprint_controller_unit_test.go
+++ b/manager/controllers/app/blueprint_controller_unit_test.go
@@ -49,6 +49,7 @@ func TestBlueprintReconcile(t *testing.T) {
 	blueprint, err := readBlueprint("../../testdata/blueprint.yaml")
 	g.Expect(err).To(gomega.BeNil(), "Cannot read blueprint file for test")
 	blueprint.Namespace = blueprintNamespace
+	blueprint.Spec.ModulesNamespace = blueprintNamespace
 
 	// Objects to track in the fake client.
 	objs := []runtime.Object{

--- a/manager/controllers/app/blueprint_controller_unit_test.go
+++ b/manager/controllers/app/blueprint_controller_unit_test.go
@@ -49,7 +49,7 @@ func TestBlueprintReconcile(t *testing.T) {
 	blueprint, err := readBlueprint("../../testdata/blueprint.yaml")
 	g.Expect(err).To(gomega.BeNil(), "Cannot read blueprint file for test")
 	blueprint.Namespace = blueprintNamespace
-	blueprint.Spec.ModulesNamespace = blueprintNamespace
+	blueprint.Spec.ModulesNamespace = utils.GetDefaultModulesNamespace()
 
 	// Objects to track in the fake client.
 	objs := []runtime.Object{

--- a/pipeline/bootstrap-pipeline.sh
+++ b/pipeline/bootstrap-pipeline.sh
@@ -369,6 +369,11 @@ if [[ ${is_openshift} == "true" ]]; then
 else
     kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "regcred"}]}'
     kubectl patch serviceaccount default -p '{"secrets": [{"name": "regcred"}]}'
+
+    if [[ ${cluster_scoped} == "false" ]]; then
+      kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "regcred"}]}' -n ${modules_namespace}
+      kubectl patch serviceaccount default -p '{"secrets": [{"name": "regcred"}]}' -n ${modules_namespace}
+    fi
 fi
 
 extra_params="${extra_params} -p deployVault='true'"


### PR DESCRIPTION
Patch default service account for non-kind clusters with registry credentials.
Set modulesNamespace in blueprint testcases.

Signed-off-by: laurieaw laurieaw@us.ibm.com