### PR TITLE
dev: correct the make command for local multi-cluster setup shell script

### DIFF
--- a/hack/setup-local-multi-cluster.sh
+++ b/hack/setup-local-multi-cluster.sh
@@ -12,7 +12,7 @@ kubectl config use-context kind-control
 make -C third_party/razee all
 
 kubectl config use-context kind-control
-make -C cluster-prepare
+make cluster-prepare
 make docker-minimal-it
 make cluster-prepare-wait
 make deploy


### PR DESCRIPTION
`Make -C cluster-prepare` means changing to the directory `cluster-prepare`, but I cannot find this directory, so I think it maybe a `make target`.