### PR TITLE
Follow-up logging tasks

### DIFF
--- a/manager/controllers/app/fybrikapplication_controller.go
+++ b/manager/controllers/app/fybrikapplication_controller.go
@@ -436,10 +436,11 @@ func (r *FybrikApplicationReconciler) constructDataInfo(req *DataInfo, input *ap
 	req.DataDetails = dataDetails
 	req.VaultSecretPath = ""
 	req.VaultSecretPath = response.Credentials
-
+	uuid := utils.GetFybrikApplicationUUID(input)
 	configEvaluatorInput := &adminconfig.EvaluatorInput{}
 	configEvaluatorInput.Workload.Properties = input.Spec.AppInfo.DeepCopy()
 	configEvaluatorInput.Workload.Cluster = workloadCluster
+	configEvaluatorInput.Workload.UUID = uuid
 	configEvaluatorInput.Request = CreateDataRequest(input, *req.Context, req.DataDetails.Metadata)
 	// Read policies for data that is processed in the workload geography
 	if configEvaluatorInput.Request.Usage[api.ReadFlow] {
@@ -451,7 +452,7 @@ func (r *FybrikApplicationReconciler) constructDataInfo(req *DataInfo, input *ap
 		}
 	}
 	configEvaluatorInput.GovernanceActions = req.Actions
-	configDecisions, err := r.ConfigEvaluator.Evaluate(configEvaluatorInput)
+	configDecisions, err := r.ConfigEvaluator.Evaluate(configEvaluatorInput, r.Log)
 	if err != nil {
 		r.Log.Error().Err(err).Msg("Error evaluating config policies")
 		return err

--- a/manager/controllers/app/fybrikapplication_controller_unit_test.go
+++ b/manager/controllers/app/fybrikapplication_controller_unit_test.go
@@ -61,7 +61,7 @@ func createClusterMetadata() *corev1.ConfigMap {
 func createTestFybrikApplicationController(cl client.Client, s *runtime.Scheme) *FybrikApplicationReconciler {
 	// environment: cluster-metadata configmap
 	_ = cl.Create(context.Background(), createClusterMetadata())
-	adminConfigEvaluator := adminconfig.NewRegoPolicyEvaluator(ctrl.Log.WithName("ConfigPolicyEvaluator"))
+	adminConfigEvaluator := adminconfig.NewRegoPolicyEvaluator()
 	// Create a FybrikApplicationReconciler object with the scheme and fake client.
 	return &FybrikApplicationReconciler{
 		Client:        cl,
@@ -96,6 +96,7 @@ func TestFybrikApplicationControllerCSVCopyAndRead(t *testing.T) {
 	application := &app.FybrikApplication{}
 	g.Expect(readObjectFromFile("../../testdata/unittests/fybrikcopyapp-csv.yaml", application)).To(gomega.BeNil(), "Cannot read fybrikapplication file for test")
 	application.SetGeneration(1)
+	application.SetUID("1")
 
 	// Objects to track in the fake client.
 	objs := []runtime.Object{
@@ -248,6 +249,7 @@ func TestDenyOnRead(t *testing.T) {
 		Requirements: app.DataRequirements{Interface: app.InterfaceDetails{Protocol: app.S3, DataFormat: app.Parquet}},
 	}
 	application.SetGeneration(1)
+	application.SetUID("2")
 	// Objects to track in the fake client.
 	objs := []runtime.Object{
 		application,
@@ -298,7 +300,7 @@ func TestNoReadPath(t *testing.T) {
 		Requirements: app.DataRequirements{Interface: app.InterfaceDetails{Protocol: app.JdbcDb2, DataFormat: app.Table}},
 	}
 	application.SetGeneration(1)
-
+	application.SetUID("3")
 	// Objects to track in the fake client.
 	objs := []runtime.Object{
 		application,
@@ -361,7 +363,7 @@ func TestWrongCopyModule(t *testing.T) {
 		},
 	}
 	application.SetGeneration(1)
-
+	application.SetUID("4")
 	// Objects to track in the fake client.
 	objs := []runtime.Object{
 		application,
@@ -420,7 +422,7 @@ func TestActionSupport(t *testing.T) {
 		Requirements: app.DataRequirements{Interface: app.InterfaceDetails{Protocol: app.ArrowFlight, DataFormat: app.Arrow}},
 	}
 	application.SetGeneration(1)
-
+	application.SetUID("5")
 	// Objects to track in the fake client.
 	objs := []runtime.Object{
 		application,
@@ -493,7 +495,7 @@ func TestMultipleDatasets(t *testing.T) {
 		},
 	}
 	application.SetGeneration(1)
-
+	application.SetUID("6")
 	// Objects to track in the fake client.
 	objs := []runtime.Object{
 		application,
@@ -587,7 +589,7 @@ func TestReadyAssetAfterUnsupported(t *testing.T) {
 		},
 	}
 	application.SetGeneration(1)
-
+	application.SetUID("7")
 	// Objects to track in the fake client.
 	objs := []runtime.Object{
 		application,
@@ -642,7 +644,7 @@ func TestMultipleRegions(t *testing.T) {
 		Requirements: app.DataRequirements{Interface: app.InterfaceDetails{Protocol: app.ArrowFlight, DataFormat: app.Arrow}},
 	}
 	application.SetGeneration(1)
-
+	application.SetUID("8")
 	// Objects to track in the fake client.
 	objs := []runtime.Object{
 		application,
@@ -723,7 +725,7 @@ func TestCopyData(t *testing.T) {
 	g.Expect(readObjectFromFile("../../testdata/unittests/ingest.yaml", application)).NotTo(gomega.HaveOccurred())
 	application.Spec.Data[0].DataSetID = assetName
 	application.SetGeneration(1)
-
+	application.SetUID("9")
 	// Objects to track in the fake client.
 	objs := []runtime.Object{
 		application,
@@ -812,7 +814,7 @@ func TestCopyDataNotAllowed(t *testing.T) {
 	g.Expect(readObjectFromFile("../../testdata/unittests/ingest.yaml", application)).NotTo(gomega.HaveOccurred())
 	application.Spec.Data[0].DataSetID = assetName
 	application.SetGeneration(1)
-
+	application.SetUID("10")
 	// Objects to track in the fake client.
 	objs := []runtime.Object{
 		application,
@@ -873,7 +875,7 @@ func TestPlotterUpdate(t *testing.T) {
 		Requirements: app.DataRequirements{Interface: app.InterfaceDetails{Protocol: app.ArrowFlight, DataFormat: app.Arrow}},
 	}
 	application.SetGeneration(1)
-
+	application.SetUID("11")
 	// Objects to track in the fake client.
 	objs := []runtime.Object{
 		application,
@@ -952,6 +954,7 @@ func TestSyncWithPlotter(t *testing.T) {
 	g.Expect(readObjectFromFile("../../testdata/unittests/fybrikcopyapp-csv.yaml", application)).NotTo(gomega.HaveOccurred())
 	// imitate a ready phase for the earlier generation
 	application.SetGeneration(2)
+	application.SetUID("12")
 	application.Finalizers = []string{"TestReconciler.finalizer"}
 	controllerNamespace := utils.GetControllerNamespace()
 	fmt.Printf("FybrikApplication unit test: controller namespace " + controllerNamespace)
@@ -1007,7 +1010,7 @@ func TestFybrikApplicationWithNoDatasets(t *testing.T) {
 	g.Expect(readObjectFromFile("../../testdata/unittests/fybrikcopyapp-csv.yaml", application)).NotTo(gomega.HaveOccurred())
 	application.Spec.Data = []app.DataContext{}
 	application.SetGeneration(1)
-
+	application.SetUID("13")
 	// Objects to track in the fake client.
 	objs := []runtime.Object{
 		application,
@@ -1053,7 +1056,7 @@ func TestFybrikApplicationWithInvalidAppInfo(t *testing.T) {
 	fybrikApp := &app.FybrikApplication{}
 	g.Expect(readObjectFromFile(filename, fybrikApp)).NotTo(gomega.HaveOccurred())
 	fybrikApp.SetGeneration(1)
-
+	fybrikApp.SetUID("14")
 	// Objects to track in the fake client.
 	objs := []runtime.Object{
 		fybrikApp,
@@ -1097,7 +1100,7 @@ func TestFybrikApplicationWithInvalidInterface(t *testing.T) {
 	fybrikApp := &app.FybrikApplication{}
 	g.Expect(readObjectFromFile(filename, fybrikApp)).NotTo(gomega.HaveOccurred())
 	fybrikApp.SetGeneration(1)
-
+	fybrikApp.SetUID("15")
 	// Objects to track in the fake client.
 	objs := []runtime.Object{
 		fybrikApp,
@@ -1140,7 +1143,7 @@ func TestCopyModule(t *testing.T) {
 	g.Expect(readObjectFromFile("../../testdata/unittests/ingest.yaml", application)).NotTo(gomega.HaveOccurred())
 	application.Spec.Data[0].DataSetID = assetName
 	application.SetGeneration(1)
-
+	application.SetUID("16")
 	// Objects to track in the fake client.
 	objs := []runtime.Object{
 		application,

--- a/manager/controllers/utils/utils.go
+++ b/manager/controllers/utils/utils.go
@@ -144,7 +144,7 @@ func Intersection(set1 []string, set2 []string) []string {
 	return res
 }
 
-const FybrikAppUUID = "FybrikApplicationUUID"
+const FybrikAppUUID = "app.fybrik.io/app-uuid"
 
 // GetFybrikApplicationUUID returns a globally unique ID for the FybrikApplication instance.
 // It must be unique over time and across clusters, even after the instance has been deleted, because this ID will be used for logging purposes.

--- a/manager/main.go
+++ b/manager/main.go
@@ -134,7 +134,7 @@ func run(namespace string, metricsAddr string, enableLeaderElection bool,
 			}
 		}()
 
-		adminConfigEvaluator := adminconfig.NewRegoPolicyEvaluator(ctrl.Log.WithName("ConfigPolicyEvaluator"))
+		adminConfigEvaluator := adminconfig.NewRegoPolicyEvaluator()
 		// Initiate the FybrikApplication Controller
 		applicationController := app.NewFybrikApplicationReconciler(
 			mgr,

--- a/pkg/adminconfig/evaluator_interface.go
+++ b/pkg/adminconfig/evaluator_interface.go
@@ -3,7 +3,9 @@
 
 package adminconfig
 
+import "github.com/rs/zerolog"
+
 // EvaluatorInterface is an interface for config policies' evaluator
 type EvaluatorInterface interface {
-	Evaluate(in *EvaluatorInput) (EvaluatorOutput, error)
+	Evaluate(in *EvaluatorInput, log zerolog.Logger) (EvaluatorOutput, error)
 }

--- a/pkg/adminconfig/rego_file_evaluator.go
+++ b/pkg/adminconfig/rego_file_evaluator.go
@@ -10,10 +10,11 @@ import (
 	"strings"
 
 	"fybrik.io/fybrik/manager/controllers/utils"
-	"github.com/go-logr/logr"
+	"fybrik.io/fybrik/pkg/logging"
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
 )
@@ -27,15 +28,13 @@ const RegoPolicyDirectory = "/tmp/adminconfig/"
 
 // RegoPolicyEvaluator implements EvaluatorInterface
 type RegoPolicyEvaluator struct {
-	Log          logr.Logger
 	Query        rego.PreparedEvalQuery
 	ReadyForEval bool
 }
 
 // NewRegoPolicyEvaluator constructs a new RegoPolicyEvaluator object
-func NewRegoPolicyEvaluator(log logr.Logger) *RegoPolicyEvaluator {
+func NewRegoPolicyEvaluator() *RegoPolicyEvaluator {
 	return &RegoPolicyEvaluator{
-		Log:          log,
 		Query:        rego.PreparedEvalQuery{},
 		ReadyForEval: false,
 	}
@@ -44,7 +43,7 @@ func NewRegoPolicyEvaluator(log logr.Logger) *RegoPolicyEvaluator {
 // prepareQuery prepares a query for OPA evaluation - data object and compiled modules.
 // This function is called upon the change in rego files.
 // Monitoring changes in rego files will be implemented in the future version.
-func (r *RegoPolicyEvaluator) prepareQuery() (rego.PreparedEvalQuery, error) {
+func (r *RegoPolicyEvaluator) prepareQuery(log zerolog.Logger) (rego.PreparedEvalQuery, error) {
 	// read and compile rego files
 	files, err := ioutil.ReadDir(RegoPolicyDirectory)
 	if err != nil {
@@ -76,15 +75,16 @@ func (r *RegoPolicyEvaluator) prepareQuery() (rego.PreparedEvalQuery, error) {
 }
 
 // Evaluate method evaluates the rego files based on the dynamic input object
-func (r *RegoPolicyEvaluator) Evaluate(in *EvaluatorInput) (EvaluatorOutput, error) {
+func (r *RegoPolicyEvaluator) Evaluate(in *EvaluatorInput, log zerolog.Logger) (EvaluatorOutput, error) {
+	evaluatorLog := log.With().Str(utils.FybrikAppUUID, in.Workload.UUID).Logger()
 	if !r.ReadyForEval {
 		var err error
-		if r.Query, err = r.prepareQuery(); err != nil {
+		if r.Query, err = r.prepareQuery(evaluatorLog); err != nil {
 			return EvaluatorOutput{Valid: false}, errors.Wrap(err, "failed to prepare a query")
 		}
 		r.ReadyForEval = true
 	}
-	input, err := r.prepareInputForOPA(in)
+	input, err := r.prepareInputForOPA(in, evaluatorLog)
 
 	if err != nil {
 		return EvaluatorOutput{Valid: false}, errors.Wrap(err, "failed to prepare an input for OPA")
@@ -94,10 +94,9 @@ func (r *RegoPolicyEvaluator) Evaluate(in *EvaluatorInput) (EvaluatorOutput, err
 	if err != nil {
 		return EvaluatorOutput{Valid: false}, errors.Wrap(err, "failed to evaluate a query")
 	}
-	bytes, _ := yaml.Marshal(&rs)
-	r.Log.V(1).Info("Response: " + string(bytes))
+	logging.LogStructure("Admin policy evaluation", &rs, evaluatorLog, false, true)
 	// merge decisions and build an output object for the manager
-	decisions, valid, err := r.getOPADecisions(in, rs)
+	decisions, valid, err := r.getOPADecisions(in, rs, evaluatorLog)
 	if err != nil {
 		return EvaluatorOutput{Valid: valid, DatasetID: in.Request.DatasetID, ConfigDecisions: decisions}, err
 	}
@@ -111,19 +110,19 @@ func (r *RegoPolicyEvaluator) Evaluate(in *EvaluatorInput) (EvaluatorOutput, err
 }
 
 // prepares an input in OPA format
-func (r *RegoPolicyEvaluator) prepareInputForOPA(in *EvaluatorInput) (map[string]interface{}, error) {
+func (r *RegoPolicyEvaluator) prepareInputForOPA(in *EvaluatorInput, log zerolog.Logger) (map[string]interface{}, error) {
+	logging.LogStructure("Evaluator Input", in, log, false, false)
 	var input map[string]interface{}
 	bytes, err := yaml.Marshal(in)
 	if err != nil {
 		return input, errors.Wrap(err, "failed to marshal the input structure")
 	}
-	r.Log.V(1).Info("Input:\n" + string(bytes))
 	err = yaml.Unmarshal(bytes, &input)
 	return input, errors.Wrap(err, "failed  to unmarshal the input structure")
 }
 
 // getOPADecisions parses the OPA decisions and merges decisions for the same capability
-func (r *RegoPolicyEvaluator) getOPADecisions(in *EvaluatorInput, rs rego.ResultSet) (DecisionPerCapabilityMap, bool, error) {
+func (r *RegoPolicyEvaluator) getOPADecisions(in *EvaluatorInput, rs rego.ResultSet, log zerolog.Logger) (DecisionPerCapabilityMap, bool, error) {
 	decisions := map[string]Decision{}
 	if len(rs) == 0 {
 		return decisions, false, errors.New("invalid opa evaluation - an empty result set has been received")
@@ -163,7 +162,8 @@ func (r *RegoPolicyEvaluator) getOPADecisions(in *EvaluatorInput, rs rego.Result
 					} else {
 						valid, mergedDecision := r.merge(newDecision, decision)
 						if !valid {
-							r.Log.Error(errors.New("Conflict"), "while merging OPA decisions", "decisions", decision.Policy.Description, "decision", newDecision.Policy.Description)
+							joinedStr := strings.Join([]string{decision.Policy.Description, newDecision.Policy.Description}, ";")
+							log.Error().Str("decisions", joinedStr).Msg("Conflict while merging OPA decisions")
 							return decisions, false, nil
 						}
 						decisions[capability] = mergedDecision


### PR DESCRIPTION
Signed-off-by: Shlomit Koyfman <shlomitk@il.ibm.com>

More updates to #926:

    - Changed label to app-uuid instead of FybrikApplicationUUID.
    - Added uuid to unit tests for easier debugging
    - Added uuid to adminconfig policy evaluator input
    - Replaced logging methods in pkg/adminconfig
