### PR TITLE
Fix Tabbed extension.

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -24,7 +24,7 @@ jobs:
           python-version: 3.8
       - name: Install Material for MkDocs
         run: |
-          pip install mkdocs-material
+          pip install mkdocs-material=="8.*"
           pip install mike
       - name: setup git config
         run: |

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -75,7 +75,8 @@ markdown_extensions:
   - meta
   - pymdownx.highlight
   - pymdownx.details
-  - pymdownx.tabbed
+  - pymdownx.tabbed:
+      alternate_style: true
   - pymdownx.superfences
   - pymdownx.emoji:
       emoji_index: !!python/name:materialx.emoji.twemoji


### PR DESCRIPTION
MkDocs's support for the legacy style of the Tabbed extension was dropped and there is a new, alternate implementation.

Fixes #1037 

Signed-off-by: nassarmu10 <mohammad.nassar@ibm.com>