### PR TITLE
Fix spellings and formatting

### DIFF
--- a/site/docs/concepts/architecture.md
+++ b/site/docs/concepts/architecture.md
@@ -5,7 +5,7 @@ and securing the use of data across an organization. The figure below showcases 
 current architecture of the Fybrik platform, running on top of Kubernetes. 
 The storage systems shown in the lower half of the figure are merely an example.
 
-The core parts of Fybrik are based on [Kubernetes operators](https://www.openshift.com/learn/topics/operators) and custom resource definitions in order to define its work items and reconcile the state of them.
+The core parts of Fybrik are based on Kubernetes controllers and Custom Resource Definitions (CRDs) in order to define its work items and reconcile the state of them.
 
 The primary interaction object for a data user is the `FybrikApplication` CRD where a user defines which data should be used for which purpose. The following chart and description describe the architecture and components of Fybrik relative to when they are used.
 
@@ -18,7 +18,7 @@ Fybrik connects to external services to receive data governance decisions, metad
 
 Once a developer submits a `FybrikApplication` CRD to Kubernetes, the FybrikApplicationController will make sure that all the specs are fulfilled and will make sure that the data is read/written/copied/deleted according to the data governance policies. The `FybrikApplication` holds metadata about the application such as the data assets required by the application, the processing purpose and the method of access the user wishes (protocol e.g. S3 or Arrow flight). 
 It uses this information to check with the data governance policy manager (4) if the data flow requested is allowed
-and whether restrictive policies such as masking or hashing have to be applied. It compiles plotters based on on the governance decisions received via the data governance policy connector and chooses the modules (5) which are best fit for the requirements that the user specified regarding the access protocol and availability, and based on the [config policies](./config-policies.md) defined.
+and whether restrictive policies such as masking or hashing have to be applied. It compiles plotters based on the governance decisions received via the data governance policy connector and chooses the modules (5) which are best fit for the requirements that the user specified regarding the access protocol and availability, and based on the [config policies](./config-policies.md) defined.
 As data assets may reside in different clusters/clouds a `Blueprint` CRD is created for each cluster, containing the information regarding the services to be deployed or configured in the given cluster.
 
 Depending on the setup the `PlotterController` will use various methods to distribute the blueprints. In a multi cluster setup the default distribution implementation is using [Razee](http://razee.io) to control remote blueprints, but several multi-cloud tools

--- a/site/docs/concepts/connectors.md
+++ b/site/docs/concepts/connectors.md
@@ -11,7 +11,7 @@ Connectors are [Open API](https://www.openapis.org/) services that the Fybrik co
 
 Yes. Fybrik provides some default connectors described in this page but anyone can develop their own connectors.
 
-A connector needs to implement one or more of the interfaces described in the [API documentation](../reference/connectors.md), depending on the connector type. Note that a single Kubernetes service can implement all interfaces if the system it connects to supports the required functionality, but it can also be different services.
+A connector needs to implement one or more of the interfaces described in the [API documentation](../reference/connectors.md), depending on the connector type. Note that a single Kubernetes service can implement all interfaces if the system it connects to, supports the required functionality, but it can also be different services.
 
 In addition, to benefit from the [control plane security](../tasks/control-plane-security.md) feature ensure that the `Pods` of your connector:
 1. Have a `fybrik.io/componentType: connector` label 
@@ -34,7 +34,7 @@ The default installation of Fybrik installs [Katalog](../reference/katalog.md), 
 Data governance policies are defined externally in the data governance manager of choice. 
 
 Enforcing data governance policies requires a Policy Decision Point (PDP) that dictates what enforcement actions need to take place.
-Fybrik supports a wide and extendible set of enforcement actions to perform on data read, copy, (future) write or delete. These include transformation of data, verification of the data, and various restrictions on the external activity of an application that can access the data.
+Fybrik supports a wide and extendable set of enforcement actions to perform on data read, copy, (future) write or delete. These include transformation of data, verification of the data, and various restrictions on the external activity of an application that can access the data.
 
 A PDP returns a list of enforcement actions given a set of policies and specific context about the application and the data it uses. 
 Fybrik includes a PDP that is powered by [Open Policy Agent](https://www.openpolicyagent.org/) (OPA). However, the PDP can also use external policy managers via connectors, to cover some or even all policy types. 

--- a/site/docs/concepts/introduction.md
+++ b/site/docs/concepts/introduction.md
@@ -6,7 +6,7 @@ Fybrik allows:
 
 * **Data users** to use data in a self-service model without manual processes, without needing to confer with data stewards, and without dealing with credentials. Use common tools and frameworks for reading from and exporting data to data lakes or data warehouses.
 * **Data stewards** to control data usage by applications. Use the organization's _policy manager_ and _data catalog_ of choice and let Fybrik automatically enforce data governance policies, whether they be based on laws, industry standards or enterprise policies.
-* **Data operators** to automate data lifecycle mangement removing the need for manual processes and custom jobs created by data operators, providing them with [config policies](.config-policies.md) to optimize the data flows orchestrated by fybrik.
+* **Data operators** to automate data lifecycle management removing the need for manual processes and custom jobs created by data operators, providing them with [config policies](./config-policies.md) to optimize the data flows orchestrated by fybrik.
 
 ## How does it work?
 
@@ -23,7 +23,7 @@ The plotter augments the application workload and data sources with additional s
 
 - Integrates business logic with non-functional data centric requirements such as enabling data access regardless of its physical location, caching, lineage tracking, etc.
 - Enforces governance relating to the data and its lifecycle; including limiting what data the business logic can access, performing transformations as needed, controlling what the business logic can export and to where
-- Makes data available in locations where it is needed. Thus in a multi cluster scenario it may copy data from one location to another, something known as an implicit copy.  The implicit copy is deleted when no longer needed.
+- Makes data available in locations where it is needed. Thus, in a multi cluster scenario it may copy data from one location to another, something known as an implicit copy.  The implicit copy is deleted when no longer needed.
 
 Fybrik is an open solution that can be extended to work with a wide range of tools and data stores. For example, the injectable [modules](./modules.md) and the [connectors](./connectors.md) to external systems (e.g., to a data catalog) can all be third party.
 
@@ -48,5 +48,5 @@ Instead, modules run in the data path to handle access to data, including passin
 ## Multicluster
 Fybrik supports data paths that access data stores that are external to the cluster such as cloud managed object stores or databases as well as data stores within the cluster such as databases running in Kubernetes. All applications and modules however will run within a cluster that has Fybrik installed.
 
-Multi-cloud and hybrid cloud scenarios are supported out of the box by running Fybrik in multiple Kubernetes clusters and configuring the manager to use a multi-cluster coordination mechanism such as razee. This enables cases such as running, for example, transformations on-prem while creating an implicit copy of an on-prem SoR table to a public cloud storage system.
+Multi-cloud and hybrid cloud scenarios are supported out of the box by running Fybrik in multiple Kubernetes clusters and configuring the manager to use a multi-cluster coordination mechanism such as Razee. This enables cases such as running, for example, transformations on-prem while creating an implicit copy of an on-prem SoR table to a public cloud storage system.
 

--- a/site/docs/concepts/vault_plugins.md
+++ b/site/docs/concepts/vault_plugins.md
@@ -9,16 +9,13 @@ Additional secret plugins can be developed to retrieve credentials additional lo
 
 The following steps are for configuring a secret plug-in for Fybrik:
 
-1. Enable the plugin during Vault server initialization in a specific path. An example of that can be found in helm chart [values.yaml](https://github.com/fybrik/fybrik/blob/master/third_party/vault/vault-single-cluster/values.yaml) file in the project where [Vault-plugin-secrets-kubernetes-reader](https://github.com/fybrik/vault-plugin-secrets-kubernetes-reader) plugin is enabled in `kubernetes-secrets` path:
-
-
+1. Enable the plugin during Vault server initialization in a specific path. 
+<br/>An example of that can be found in helm chart [values.yaml](https://github.com/fybrik/fybrik/blob/master/third_party/vault/vault-single-cluster/values.yaml) file in the project where [Vault-plugin-secrets-kubernetes-reader](https://github.com/fybrik/vault-plugin-secrets-kubernetes-reader) plugin is enabled in `kubernetes-secrets` path:
 ```bash
       vault secrets enable -path=kubernetes-secrets vault-plugin-secrets-kubernetes-reader
 ```
-
 2. Add [Vault policy ](https://www.vaultproject.io/docs/concepts/policies) to allow the [modules](./modules.md) to access secrets using the plugin.
-Following is an example of a policy which gives permission to read secrets in Vault path `kubernetes-secrets`:
-
+<br/>Following is an example of a policy which gives permission to read secrets in Vault path `kubernetes-secrets`:
 ```bash
 vault policy write "allow-all-dataset-creds" - <<EOF
       path "kubernetes-secrets/*" {
@@ -28,9 +25,7 @@ vault policy write "allow-all-dataset-creds" - <<EOF
 ```
 3. Have the `CatalogDatasetInfo` structure from the [data catalog response](../../reference/connectors#data_catalog_responseproto) contain the Vault secret path which should be used to retrieve the credentials for a given asset. When Vault plugin is used to retrieve the credentials the parameters to the plugin should follow the plugin usage instructions. This path will later be passed on to the [modules](./modules.md).
 For example, when the credentials are stored in kubernetes secret as is done in the [Katalog](../reference/katalog.md) built-in data catalog; the [Vault-plugin-secrets-kubernetes-reader](https://github.com/fybrik/vault-plugin-secrets-kubernetes-reader) plugin can be used to retrieve the credentials. In this case two parameters should be passed: `paysim-csv`  which is the kubernetes secret name that holds the credentials and `fybrik-notebook-sample` is the secret namespace, both are known to the katalog when constructing the path.
-
-The following snippet shows `CatalogDatasetInfo` structure with Vault secret path in `CredentialsInfo` field.
-
+<br/><br/>The following snippet shows `CatalogDatasetInfo` structure with Vault secret path in `CredentialsInfo` field.
 ```bash
 	connectors.CatalogDatasetInfo{
 		DatasetId: fybrik-notebook-sample/paysim-csv,

--- a/site/docs/contribute/build-test.md
+++ b/site/docs/contribute/build-test.md
@@ -46,7 +46,7 @@ tests on it:
 make run-integration-tests
 ```
 
-It is sometimes useful to to call the integration test commands step by step, e.g., if you want to only repeat a specific step which failed without having to rerun the entire sequence. You can find the commands of the `run-integration-tests` target in the [Makefile](https://github.com/fybrik/fybrik/blob/master/Makefile).
+It is sometimes useful to call the integration test commands step by step, e.g., if you want to only repeat a specific step which failed without having to rerun the entire sequence. You can find the commands of the `run-integration-tests` target in the [Makefile](https://github.com/fybrik/fybrik/blob/master/Makefile).
 
 
 You can run `make kind-cleanup` to delete the created clusters when you're done.
@@ -55,7 +55,7 @@ You can run `make kind-cleanup` to delete the created clusters when you're done.
 
 As Fybrik can run in a multi-cluster environment there is also a test environment
 that can be used that simulates this scenario. Using kind one can spin up two separate kubernetes
-clusters with differnt contexts and develop and test in these. 
+clusters with different contexts and develop and test in these. 
 
 Two kind clusters that share the same kind-registry can be set up using:
 ```bash

--- a/site/docs/contribute/environment.md
+++ b/site/docs/contribute/environment.md
@@ -35,11 +35,11 @@ Please note: For fybrik version 0.5 and lower, Helm version greater than 3.3 but
 
 ## Editors
 
-The project is predominantly written in Go so we recommend [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.Go) for its good Go support. Alternatively you can select from [Editors](https://golang.org/doc/editors.html)
+The project is predominantly written in Go, so we recommend [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.Go) for its good Go support. Alternatively you can select from [Editors](https://golang.org/doc/editors.html)
 
 ## Docker hub rate limits
 
-As docker hub introduced rate limits on docker image downloads this may effect development using the local kind setup.
+As docker hub introduced rate limits on docker image downloads this may affect development using the local kind setup.
 One option to fix the limit is to use a docker hub login for downloading the images. The environment will run
 a docker registry as a proxy for all public images. This registry runs in a docker container next to the kind clusters. 
 

--- a/site/docs/contribute/flow.md
+++ b/site/docs/contribute/flow.md
@@ -29,7 +29,7 @@ Here’s how to submit a pull request:
     git merge upstream/master
     git push origin master
     ```
-- **[Create a branch](https://guides.github.com/introduction/flow/)** for your edits from master. Note that your should never add edits to the master branch itself.
+- **[Create a branch](https://guides.github.com/introduction/flow/)** for your edits from master. Note that you should never add edits to the master branch itself.
     ```shell
     git checkout -b <branch name>
     ```

--- a/site/docs/contribute/logging.md
+++ b/site/docs/contribute/logging.md
@@ -4,7 +4,7 @@ This page describes the information that your code should provide in all log ent
 
 # Background
 * Log entries should be written to stdout and stderr.
-* Fybrik does not collect nor aggregate logs.  This may be done by external tools. (ex: logstash, fluentd, etc)
+* Fybrik does not collect nor aggregate logs.  This may be done by external tools. (ex: logstash, fluentd, etc.)
 * A globally unique identifier for each FybrikApplication instance is passed to all control plane and data plane components to be included in log entries.  This enables corrrelation of log entries across different logs and clusters for the specific instance, even if the name of the FybrikApplication is reused over time.
 
 # Log Entry Contents

--- a/site/docs/contribute/modules.md
+++ b/site/docs/contribute/modules.md
@@ -38,7 +38,7 @@ $ curl --header "X-Vault-Token: ..." -X GET https://<address>/<secretPath>
 
 For any module chosen by the control plane to be part of the data path, the control plane needs to be able to install/remove/upgrade an instance of the module. Fybrik uses [Helm](https://helm.sh/docs/intro/using_helm/) to provide this functionality. Follow the Helm [getting started](https://helm.sh/docs/chart_template_guide/getting_started/) guide if you are unfamiliar with Helm. Note that Helm 3.3 or above is required.
 
-The names of the Kubernetes resources deployed by the module helm chart must contain the release name to avoid resource conflicts. A Kubernetes `service` resource which is used to access the module must have a name equal to the release name (this service name is also used in the optional [`spec.capabilites.api.endpoint.hostname`](../reference/crds.md#fybrikmodulespeccapabilitiesapiendpoint) field).
+The names of the Kubernetes resources deployed by the module helm chart must contain the release name to avoid resource conflicts. A Kubernetes `service` resource which is used to access the module must have a name equal to the release name (this service name is also used in the optional [`spec.capabilities.api.endpoint.hostname`](../reference/crds.md#fybrikmodulespeccapabilitiesapiendpoint) field).
 
 Because the chart is installed by the control plane, the input `values` to the chart must match the relevant type of [arguments](../reference/crds.md#blueprintspecflowstepsindexarguments). 
 <!-- TODO: expand this when we support setting values in the FybrikModule YAML: https://github.com/fybrik/fybrik/pull/42 -->

--- a/site/docs/tasks/multicluster.md
+++ b/site/docs/tasks/multicluster.md
@@ -1,7 +1,7 @@
 # Multicluster setup
 
 Fybrik is dynamic in its multi cluster capabilities in that it has abstractions to support multiple
-different cross-cluster orchestration mechanisms. Currently only one multi cluster orchestration mechanism is implemented
+different cross-cluster orchestration mechanisms. Currently, only one multi cluster orchestration mechanism is implemented
 and is using [Razee](http://razee.io) for the orchestration.
 
 ## Multicluster operation with Razee
@@ -32,7 +32,7 @@ Please follow the instructions in the Razee documentation to install [RazeeDash]
 the [cluster subscription agent](https://github.com/razee-io/Razee/blob/master/README.md#automating-the-deployment-of-kubernetes-resources-across-clusters-and-environments).
 At the moment Razee supports GitHub, GitHub Enterprise and BitBucket for the OAUTH Authentication of this installation.
 
-Please be aware that the RazeeDash API needs to be reachable from all clusters. Thus there may be the need for routes, ingresses or node ports
+Please be aware that the RazeeDash API needs to be reachable from all clusters. Thus, there may be the need for routes, ingresses or node ports
  in order to expose it to other networks and clusters.
 
 <!-- TODO maybe add a description on how to install it including openshift routes etc -->

--- a/site/docs/tasks/using-opa.md
+++ b/site/docs/tasks/using-opa.md
@@ -5,7 +5,7 @@ When OPA is used for data governance, it is deployed as a stand-alone service.  
 
 There are [several ways](https://www.openpolicyagent.org/docs/latest/management/) to manage policies and data of the OPA service. 
 
-One simple approach is to use [OPA kube-mgmt](https://github.com/open-policy-agent/kube-mgmt) and manage Rego policies in Kubernetes `Configmap` resources. By default Fybrik installs OPA with kube-mgmt enabled. 
+One simple approach is to use [OPA kube-mgmt](https://github.com/open-policy-agent/kube-mgmt) and manage Rego policies in Kubernetes `Configmap` resources. By default, Fybrik installs OPA with kube-mgmt enabled. 
 
 This task shows how to use OPA with kube-mgmt.
 


### PR DESCRIPTION
- remove reference to OpenShift operators from `architecture.md`
- fix reference to `./config-policies.md` in `introduction.md`
- fix formatting in `vault_plugins.md`
- fix spelling typos 

Signed-off-by: Alexey Roytman <roytman@il.ibm.com>