### PR TITLE
doc: fix copy command for running manager locally

### DIFF
--- a/manager/README.md
+++ b/manager/README.md
@@ -64,8 +64,8 @@ set -a; . .env; set +a
 
 ### Copy taxonomy JSON files and config policies locally
 ```bash
-cp -R ../charts/fybrik/files/taxonomy /tmp
-cp -R ../charts/fybrik/files/adminconfig/* /tmp/adminconfig/
+cp -R ../charts/fybrik/files/taxonomy /tmp/
+cp -R ../charts/fybrik/files/adminconfig /tmp/
 ```
 
 ### Run the manager


### PR DESCRIPTION
The command fails to execute because the directory "/tmp/adminconfig" does not exist. 
```shell
cp -R ../charts/fybrik/files/adminconfig/* /tmp/adminconfig/
```

```shell
cp: target '/tmp/adminconfig/' is not a directory
```

So I try to change this command to
```shell
cp -R ../charts/fybrik/files/adminconfig /tmp/
```