### PR TITLE
Move makefile targets from manager to root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ include Makefile.env
 export DOCKER_TAGNAME ?= master
 export KUBE_NAMESPACE ?= fybrik-system
 
+.PHONY: all
 all: generate manifests verify
 
 .PHONY: license

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ include Makefile.env
 export DOCKER_TAGNAME ?= master
 export KUBE_NAMESPACE ?= fybrik-system
 
+all: generate manifests verify
+
 .PHONY: license
 license: $(TOOLBIN)/license_finder
 	$(call license_go,.)
@@ -11,6 +13,17 @@ generate: $(TOOLBIN)/controller-gen $(TOOLBIN)/json-schema-generator
 	$(TOOLBIN)/json-schema-generator -r ./pkg/model/... -o charts/fybrik/files/taxonomy/
 	$(TOOLBIN)/controller-gen object:headerFile=./hack/boilerplate.go.txt,year=$(shell date +%Y) paths="./..."
 	$(MAKE) -C site generate
+
+.PHONY: manifests
+manifests: $(TOOLBIN)/controller-gen $(TOOLBIN)/yq
+	$(TOOLBIN)/controller-gen --version
+	$(TOOLBIN)/controller-gen crd output:crd:artifacts:config=charts/fybrik-crd/templates/ paths=./manager/apis/...
+	$(TOOLBIN)/controller-gen webhook paths=./manager/apis/... output:stdout | \
+		$(TOOLBIN)/yq eval '.metadata.annotations."cert-manager.io/inject-ca-from" |= "{{ .Release.Namespace }}/serving-cert"' - | \
+		$(TOOLBIN)/yq eval '.metadata.annotations."certmanager.k8s.io/inject-ca-from" |= "{{ .Release.Namespace }}/serving-cert"' - | \
+		$(TOOLBIN)/yq eval '(.metadata.name | select(. == "mutating-webhook-configuration")) = "{{ .Release.Namespace }}-mutating-webhook"' - | \
+		$(TOOLBIN)/yq eval '(.metadata.name | select(. == "validating-webhook-configuration")) = "{{ .Release.Namespace }}-validating-webhook"' - | \
+		$(TOOLBIN)/yq eval '(.webhooks.[].clientConfig.service.namespace) = "{{ .Release.Namespace }}"' - > charts/fybrik/files/webhook-configs.yaml
 
 .PHONY: docker-mirror-read
 docker-mirror-read:
@@ -25,13 +38,25 @@ deploy: $(TOOLBIN)/kubectl $(TOOLBIN)/helm
 	$(TOOLBIN)/helm install fybrik charts/fybrik --values $(VALUES_FILE) \
                --namespace $(KUBE_NAMESPACE) --wait --timeout 120s
 
+pre-test: generate manifests $(TOOLBIN)/etcd $(TOOLBIN)/kube-apiserver
+	mkdir -p /tmp/taxonomy
+	mkdir -p /tmp/adminconfig
+	cp charts/fybrik/files/taxonomy/*.json /tmp/taxonomy/
+	cp charts/fybrik/files/adminconfig/*.rego /tmp/adminconfig/
+	mkdir -p manager/testdata/unittests/basetaxonomy
+	mkdir -p manager/testdata/unittests/sampletaxonomy
+	cp charts/fybrik/files/taxonomy/*.json manager/testdata/unittests/basetaxonomy
+	cp charts/fybrik/files/taxonomy/*.json manager/testdata/unittests/sampletaxonomy
+	go run main.go taxonomy compile -o manager/testdata/unittests/sampletaxonomy/taxonomy.json \
+  	-b charts/fybrik/files/taxonomy/taxonomy.json \
+		$(shell find samples/taxonomy/example -type f -name '*.yaml')
+	cp manager/testdata/unittests/sampletaxonomy/taxonomy.json /tmp/taxonomy/taxonomy.json
+
 .PHONY: test
 test: export MODULES_NAMESPACE?=fybrik-blueprints
 test: export CONTROLLER_NAMESPACE?=fybrik-system
-test:
-	$(MAKE) -C manager pre-test
+test: pre-test
 	go test -v ./...
-	# The tests for connectors/egeria are dropped because there are none
 
 .PHONY: run-integration-tests
 run-integration-tests: export DOCKER_HOSTNAME?=localhost:5000
@@ -64,18 +89,6 @@ run-notebook-tests:
 	$(MAKE) deploy
 	$(MAKE) configure-vault
 	$(MAKE) -C manager run-notebook-tests
-
-.PHONY: run-deploy-tests
-run-deploy-tests:
-	$(MAKE) kind
-	$(MAKE) cluster-prepare
-	kubectl config set-context --current --namespace=$(KUBE_NAMESPACE)
-	$(MAKE) -C third_party/opa deploy
-	kubectl apply -f ./manager/config/prod/deployment_configmap.yaml
-	$(MAKE) -C connectors deploy
-	kubectl get pod --all-namespaces
-	kubectl wait --for=condition=ready pod --all-namespaces --all --timeout=120s
-	$(MAKE) configure-vault
 
 .PHONY: cluster-prepare
 cluster-prepare:

--- a/manager/Makefile
+++ b/manager/Makefile
@@ -4,14 +4,13 @@ include $(ROOT_DIR)/Makefile.env
 .PHONY: all
 all: manager
 
+DOCKER_NAME ?= manager
+KUBE_NAMESPACE ?= fybrik-system
+CONTROLLER_NAMESPACE ?= ${KUBE_NAMESPACE}
+
 include $(ROOT_DIR)/hack/make-rules/tools.mk
 include $(ROOT_DIR)/hack/make-rules/docker.mk
 include $(ROOT_DIR)/hack/make-rules/verify.mk
-
-DOCKER_NAME ?= manager
-GO_OUTPUT_FILE = manager
-KUBE_NAMESPACE ?= fybrik-system
-CONTROLLER_NAMESPACE ?= ${KUBE_NAMESPACE}
 
 # Build manager binary
 manager:

--- a/manager/Makefile
+++ b/manager/Makefile
@@ -1,72 +1,31 @@
 ROOT_DIR := ..
 include $(ROOT_DIR)/Makefile.env
-#include Makefile.env
 
 .PHONY: all
 all: manager
 
 include $(ROOT_DIR)/hack/make-rules/tools.mk
+include $(ROOT_DIR)/hack/make-rules/docker.mk
+include $(ROOT_DIR)/hack/make-rules/verify.mk
+
 DOCKER_NAME ?= manager
 GO_OUTPUT_FILE = manager
 KUBE_NAMESPACE ?= fybrik-system
 CONTROLLER_NAMESPACE ?= ${KUBE_NAMESPACE}
-include $(ROOT_DIR)/hack/make-rules/docker.mk
-include $(ROOT_DIR)/hack/make-rules/verify.mk
-
-
-pre-test: generate manifests $(TOOLBIN)/etcd $(TOOLBIN)/kube-apiserver
-	mkdir -p /tmp/taxonomy
-	mkdir -p /tmp/adminconfig
-	cp ../charts/fybrik/files/taxonomy/*.json /tmp/taxonomy/
-	cp ../charts/fybrik/files/adminconfig/*.rego /tmp/adminconfig/
-	mkdir -p testdata/unittests/basetaxonomy
-	mkdir -p testdata/unittests/sampletaxonomy
-	cp ../charts/fybrik/files/taxonomy/*.json testdata/unittests/basetaxonomy
-	cp ../charts/fybrik/files/taxonomy/*.json testdata/unittests/sampletaxonomy
-	go run $(ROOT_DIR)/main.go taxonomy compile -o testdata/unittests/sampletaxonomy/taxonomy.json \
-  	-b $(ROOT_DIR)/charts/fybrik/files/taxonomy/taxonomy.json \
-		$(shell find $(ROOT_DIR)/samples/taxonomy/example -type f -name '*.yaml')
-	cp testdata/unittests/sampletaxonomy/taxonomy.json /tmp/taxonomy/taxonomy.json
-
-# Run tests
-test: export MODULES_NAMESPACE?=fybrik-blueprints
-test: export CONTROLLER_NAMESPACE?=fybrik-system
-test: pre-test
-	go test ./... -v  -coverprofile cover.out
 
 # Build manager binary
-manager: generate fmt vet
+manager:
 	go build -o bin/manager main.go
 
-source-build: generate fmt vet
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -o manager main.go
-
 # Run against the configured Kubernetes cluster in ~/.kube/config
-run: generate fmt vet manifests
+run:
 	go run ./main.go --enable-all-controllers --metrics-bind-addr=0
 
-# Generate code
-# TODO: all generation should move to the top-level makefile
-.PHONY: generate
-generate: $(TOOLBIN)/controller-gen
-	$(TOOLBIN)/controller-gen --version
-	$(TOOLBIN)/controller-gen object:headerFile=$(ROOT_DIR)/hack/boilerplate.go.txt,year=$(shell date +%Y) paths="$(ROOT_DIR)/..."
-	$(MAKE) -C $(ROOT_DIR)/site generate
-
-# Generate manifests e.g. CRD, RBAC etc.
-.PHONY: manifests
-manifests: $(TOOLBIN)/controller-gen $(TOOLBIN)/yq
-	$(TOOLBIN)/controller-gen --version
-	$(TOOLBIN)/controller-gen crd output:crd:artifacts:config=$(ROOT_DIR)/charts/fybrik-crd/templates/ paths=./apis/...
-	$(TOOLBIN)/controller-gen webhook paths=./apis/... output:stdout | \
-		$(TOOLBIN)/yq eval '.metadata.annotations."cert-manager.io/inject-ca-from" |= "{{ .Release.Namespace }}/serving-cert"' - | \
-		$(TOOLBIN)/yq eval '.metadata.annotations."certmanager.k8s.io/inject-ca-from" |= "{{ .Release.Namespace }}/serving-cert"' - | \
-		$(TOOLBIN)/yq eval '(.metadata.name | select(. == "mutating-webhook-configuration")) = "{{ .Release.Namespace }}-mutating-webhook"' - | \
-		$(TOOLBIN)/yq eval '(.metadata.name | select(. == "validating-webhook-configuration")) = "{{ .Release.Namespace }}-validating-webhook"' - | \
-		$(TOOLBIN)/yq eval '(.webhooks.[].clientConfig.service.namespace) = "{{ .Release.Namespace }}"' - > $(ROOT_DIR)/charts/fybrik/files/webhook-configs.yaml
+source-build:
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -o manager main.go
 
 # Overwrite docker-build from docker.mk
-docker-build: generate source-build
+docker-build: source-build
 	docker build . -t ${IMG} -f Dockerfile
 	rm manager
 
@@ -90,10 +49,6 @@ run-notebook-tests: export USE_MOCKUP_CONNECTOR?=true
 run-notebook-tests: wait_for_manager
 	cd testdata/notebook && ./setup.sh
 	NO_SIMULATED_PROGRESS=true USE_EXISTING_CONTROLLER=true USE_EXISTING_CLUSTER=true go test ./... -v -run TestS3Notebook -count 1
-
-
-.PHONY: main.deps
-main.deps: generate fmt vet manifests
 
 DEBUG := ./debug.out
 

--- a/samples/gui/front-end/Makefile
+++ b/samples/gui/front-end/Makefile
@@ -5,7 +5,6 @@ DOCKER_NAME ?= datauserclient
 DOCKER_TAGNAME ?= latest
 DOCKER_FILE = Dockerfile
 DOCKER_CONTEXT = .
-GO_OUTPUT_FILE = datauserclient
 include $(ROOT_DIR)/hack/make-rules/docker.mk
 
 

--- a/samples/gui/server/Makefile
+++ b/samples/gui/server/Makefile
@@ -5,7 +5,6 @@ DOCKER_NAME ?= datauserserver
 DOCKER_TAGNAME ?= latest
 DOCKER_FILE = Dockerfile
 DOCKER_CONTEXT = .
-GO_OUTPUT_FILE = datauserserver
 KUBE_NAMESPACE ?= fybrik-system
 include $(ROOT_DIR)/hack/make-rules/docker.mk
 include $(ROOT_DIR)/hack/make-rules/verify.mk


### PR DESCRIPTION
* Moved manifests target
* Moved pre-test target
* Removed redundant generate target
* Removed unused run-deploy-tests target


Side effect of #1049