### PR TITLE
Change default connector url to include an http prefix

### DIFF
--- a/charts/fybrik/templates/fybrik-config.yaml
+++ b/charts/fybrik/templates/fybrik-config.yaml
@@ -11,9 +11,9 @@ data:
   DATAPATH_MAX_SIZE: {{ .Values.manager.dataPathMaxSize | quote }}
   CONNECTION_TIMEOUT: {{ .Values.manager.connectionTimeout | default .Values.global.connectionTimeout | quote }}
   CATALOG_PROVIDER_NAME: {{ .Values.coordinator.catalog | quote }}
-  CATALOG_CONNECTOR_URL: {{ .Values.coordinator.catalogConnectorURL | default (printf "%s-connector:80" .Values.coordinator.catalog) | quote }}
+  CATALOG_CONNECTOR_URL: {{ .Values.coordinator.catalogConnectorURL | default (printf "http://%s-connector:80" .Values.coordinator.catalog) | quote }}
   MAIN_POLICY_MANAGER_NAME: {{ .Values.coordinator.policyManager | quote }}
-  MAIN_POLICY_MANAGER_CONNECTOR_URL: {{ .Values.coordinator.policyManagerConnectorURL | default (printf "%s-connector:80" .Values.coordinator.policyManager) | quote }}
+  MAIN_POLICY_MANAGER_CONNECTOR_URL: {{ .Values.coordinator.policyManagerConnectorURL | default (printf "http://%s-connector:80" .Values.coordinator.policyManager) | quote }}
   VAULT_ADDRESS: {{ tpl .Values.coordinator.vault.address . | quote }}
   VAULT_MODULES_ROLE: "module" # temporary
   {{- end }}

--- a/charts/fybrik/templates/opa-connector/opa-connector-cm.yaml
+++ b/charts/fybrik/templates/opa-connector/opa-connector-cm.yaml
@@ -7,7 +7,7 @@ metadata:
 data:
   CONNECTION_TIMEOUT: {{ .Values.opaConnector.connectionTimeout | default .Values.global.connectionTimeout | quote }}
   OPA_SERVER_URL: {{ .Values.opaConnector.serverURL | default (printf "http://opa:%d" (int .Values.opaServer.service.port) ) | quote }}
-  CATALOG_CONNECTOR_URL: {{ .Values.coordinator.catalogConnectorURL | default (printf "%s-connector:80" .Values.coordinator.catalog) | quote }}
+  CATALOG_CONNECTOR_URL: {{ .Values.coordinator.catalogConnectorURL | default (printf "http://%s-connector:80" .Values.coordinator.catalog) | quote }}
   CATALOG_PROVIDER_NAME: {{ .Values.coordinator.catalog | quote }}
 
 {{- end }}

--- a/charts/fybrik/values.yaml
+++ b/charts/fybrik/values.yaml
@@ -66,6 +66,7 @@ coordinator:
   catalog: "katalog"
 
   # Overrides the catalog connector URL.
+  # Defaults to `http://<catalog>-connector:80`.
   catalogConnectorURL: ""
 
   # Configures the policy manager system name to be used by the coordinator manager.
@@ -73,6 +74,7 @@ coordinator:
   policyManager: "opa"
 
   # Overrides the policy manager connector URL.
+  # Defaults to `http://<policyManager>-connector:80`.
   policyManagerConnectorURL: ""
 
   # Configure the vault instance to be used by the coordinator manager

--- a/charts/fybrik/values.yaml
+++ b/charts/fybrik/values.yaml
@@ -66,16 +66,14 @@ coordinator:
   catalog: "katalog"
 
   # Overrides the catalog connector URL.
-  # Defaults to `<catalog>-connector:80`.
-  catalogConnectorURL: "http://katalog-connector:80"
+  catalogConnectorURL: ""
 
   # Configures the policy manager system name to be used by the coordinator manager.
   # Accepted values are "opa" or any meaningful name if a third party connector is used.
   policyManager: "opa"
 
   # Overrides the policy manager connector URL.
-  # Defaults to `<policyManager>-connector:80`.
-  policyManagerConnectorURL: "http://opa-connector:80"
+  policyManagerConnectorURL: ""
 
   # Configure the vault instance to be used by the coordinator manager
   vault:

--- a/connectors/opa/Makefile
+++ b/connectors/opa/Makefile
@@ -10,7 +10,7 @@ NEED_TEST_COVERAGE_STATISTICS=1
 NEED_TEST_COVERAGE_STATISTICS_IN_HTML=0
 
 CATALOG_PROVIDER_NAME ?= "katalog"
-CATALOG_CONNECTOR_URL ?= "katalg-connector:50090"
+CATALOG_CONNECTOR_URL ?= "http://katalog-connector:50090"
 
 docker-all: docker-build docker-push 
 

--- a/connectors/opa/testutil/helper.go
+++ b/connectors/opa/testutil/helper.go
@@ -23,7 +23,7 @@ import (
 
 var EnvValues = map[string]string{
 	"CONNECTION_TIMEOUT":    "120",
-	"CATALOG_CONNECTOR_URL": "localhost:50084",
+	"CATALOG_CONNECTOR_URL": "http://localhost:50084",
 	"OPA_SERVER_URL":        "http://localhost:8282",
 	"CATALOG_PROVIDER_NAME": "dummy_catalog",
 }

--- a/manager/controllers/utils/configuration.go
+++ b/manager/controllers/utils/configuration.go
@@ -68,12 +68,12 @@ func SetIfNotSet(key string, value string, t ginkgo.GinkgoTInterface) {
 }
 
 func DefaultTestConfiguration(t ginkgo.GinkgoTInterface) {
-	SetIfNotSet(CatalogConnectorServiceAddressKey, "localhost:50085", t)
+	SetIfNotSet(CatalogConnectorServiceAddressKey, "http://localhost:50085", t)
 	SetIfNotSet(VaultAddressKey, "http://127.0.0.1:8200/", t)
 	SetIfNotSet("RUN_WITHOUT_VAULT", "1", t)
 	SetIfNotSet("ENABLE_WEBHOOKS", "false", t)
 	SetIfNotSet("CONNECTION_TIMEOUT", "120", t)
-	SetIfNotSet("MAIN_POLICY_MANAGER_CONNECTOR_URL", "localhost:50090", t)
+	SetIfNotSet("MAIN_POLICY_MANAGER_CONNECTOR_URL", "http://localhost:50090", t)
 	SetIfNotSet("MAIN_POLICY_MANAGER_NAME", "MOCK", t)
 	SetIfNotSet("LOGGING_VERBOSITY", "-1", t)
 	SetIfNotSet("PRETTY_LOGGING", "true", t)


### PR DESCRIPTION
This PR addresses issue #1085 : it changes the default connector url to include an http prefix

Closes #1085 