### PR TITLE
multicluster: Specify the version of razee-io/ClusterSubscription

### DIFF
--- a/third_party/razee/razeedeploy-delta-install-template.yaml
+++ b/third_party/razee/razeedeploy-delta-install-template.yaml
@@ -74,7 +74,7 @@ spec:
                "--razeedash-org-key=$ORGAPIKEY",
                "--razeedash-cluster-id=$CLUSTERID",
                "--razeedash-cluster-metadata64=$CLUSTERNAMEB64",
-               "--cs", "--rr", "--rrs3", "--wk", "--mtp", "--ffsld", "--ms"]
+               "--cs=3.1.0", "--rr", "--rrs3", "--wk", "--mtp", "--ffsld", "--ms"]
         # see README.md for args options. https://github.com/razee-io/razeedeploy-delta/blob/master/README.md
       restartPolicy: Never
   backoffLimit: 2


### PR DESCRIPTION
Currently [third_party/razee](https://github.com/fybrik/fybrik/tree/master/third_party/razee) deploys `razee-io/Razeedash-api` with the version 
https://github.com/fybrik/fybrik/blob/709da393d98ee031a1918cd7508ac222b56f44fe/third_party/razee/razeedash-api.yaml#L16

but deploys the `razee-io/ClusterSubscription` with the "latest" version with `razee-io/razeedeploy-delta` https://github.com/fybrik/fybrik/blob/master/third_party/razee/razeedeploy-delta-install-template.yaml

This introduces a compatibility issue that clustersubscription in razeedeploy cannot get the graphql query result from razeedash-api in razee
```
cannot find `kubeOwnerName`
```

I checked the source code of  [razee-io/ClusterSubscription](https://github.com/razee-io/ClusterSubscription), and found `kubeOwnerName` was introduced about 10 months ago. 

So I pick a suitable version ([v3.1.0](https://github.com/razee-io/ClusterSubscription/releases/tag/3.1.0)) for razee-io/ClusterSubscription to keep the compatibility with the current version of `razee-io/Razeedash-api` deployed by `third_party/razee`, the two versions are very close in time. After the version is specified, the issue is gone.
