### PR TITLE
Fix issues after katalog-connector default to http

### DIFF
--- a/charts/fybrik/integration-tests.values.yaml
+++ b/charts/fybrik/integration-tests.values.yaml
@@ -21,10 +21,6 @@ coordinator:
   # Accepted values are "katalog", "egeria" or any meaningful name if a third party connector is used.
   catalog: "katalog"
 
-  # Overrides the catalog connector URL.
-  # Defaults to `<catalog>-connector:80`.
-  catalogConnectorURL: "http://katalog-connector:80"
-
 # Manager component
 manager:
   # Set to true to enable socat in the manager pod to forward

--- a/charts/fybrik/kind-control.values.yaml
+++ b/charts/fybrik/kind-control.values.yaml
@@ -26,7 +26,6 @@ cluster:
 
 # Configuration when deploying to a coordinator cluster.
 coordinator:
-  catalogConnectorURL: "http://katalog-connector:80"
   vault:
     # vault service in local setup is exposed via nodeport
     address: http://control-control-plane:31752

--- a/pkg/connectors/datacatalog/clients/datacatalog_grpc.go
+++ b/pkg/connectors/datacatalog/clients/datacatalog_grpc.go
@@ -64,6 +64,9 @@ func (m *grpcDataCatalog) GetAssetInfo(in *datacatalog.GetAssetRequest, creds st
 		return nil, fmt.Errorf("error Marshalling External Catalog Connector Response: %v", errJSON)
 	}
 	log.Print(string(responseBytes))
+	if responseBytes == nil {
+		return nil, fmt.Errorf("data asset does not exist")
+	}
 	dataCatalogResp, err := ConvertDataCatalogGrpcRespToOpenAPIResp(result)
 	if err != nil {
 		log.Println("Error during conversion to open api response: ", err)


### PR DESCRIPTION
1. Remove overide to `catalogConnectorURL` since it's already default now
2. Fix the panic when still use grpc client

