### PR TITLE
Add fybrik-template-0.0.0.tgz to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ third_party/egeria/egeria
 # Local development
 .env
 __debug_bin
+modules/fybrik-template/fybrik-template-0.0.0.tgz
 
 pipeline/custom_*
 pipeline/custom-pipeline.yaml


### PR DESCRIPTION
`make -C fybrik-template helm-all` generates fybrik-template-0.0.0.tgz when executing integration tests.
This PR adds fybrik-template-0.0.0.tgz to .gitignore.

@roee88 thanks for reporting.