### PR TITLE
Don't load CRD if running intergration testing in an existing cluster (PR 1128)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,4 +59,5 @@ __debug_bin
 modules/fybrik-template/fybrik-template-0.0.0.tgz
 
 pipeline/custom_*
-pipeline/custom-pipeline.yaml
+pipeline/vault_cre*
+pipeline/custom-*

--- a/manager/controllers/app/suite_test.go
+++ b/manager/controllers/app/suite_test.go
@@ -62,11 +62,20 @@ var _ = BeforeSuite(func(done Done) {
 		logf.Log.Info(pathErr.Error())
 	}
 	By("bootstrapping test environment")
-	testEnv = &envtest.Environment{
-		CRDDirectoryPaths: []string{
-			filepath.Join(path, "..", "..", "..", "charts", "fybrik-crd", "templates"),
-		},
-		ErrorIfCRDPathMissing: true,
+	if os.Getenv("USE_EXISTING_CONTROLLER") == "true" {
+		fmt.Printf("Using existing environment; don't load CRDs. \n")
+		useexistingcluster := true
+		testEnv = &envtest.Environment{
+			UseExistingCluster: &useexistingcluster,
+		}
+	} else {
+		fmt.Printf("Using fake environment; so set path to CRDs so they are installed. \n")
+		testEnv = &envtest.Environment{
+			CRDDirectoryPaths: []string{
+				filepath.Join(path, "..", "..", "..", "charts", "fybrik-crd", "templates"),
+			},
+			ErrorIfCRDPathMissing: true,
+		}
 	}
 
 	utils.DefaultTestConfiguration(GinkgoT())


### PR DESCRIPTION
External resources not being removed when app removed. Don't load CRD if running in existing cluster.

Signed-off-by: laurieaw <laurieaw@us.ibm.com>