### PR TITLE
Fix the image used by kind develop env

### DIFF
--- a/charts/fybrik/kind-control.values.yaml
+++ b/charts/fybrik/kind-control.values.yaml
@@ -5,7 +5,7 @@
 # Global configuration applies to multiple components installed by this chart
 global:
   hub: localhost:5000/fybrik-system
-  tag: "master"
+  tag: "0.0.0"
   imagePullPolicy: "Always"
 
   prettyLogging: false

--- a/charts/fybrik/kind-kind.values.yaml
+++ b/charts/fybrik/kind-kind.values.yaml
@@ -5,7 +5,7 @@
 # Global configuration applies to multiple components installed by this chart
 global:
   hub: localhost:5000/fybrik-system
-  tag: "master"
+  tag: "0.0.0"
   imagePullPolicy: "Always"
 
   prettyLogging: false


### PR DESCRIPTION
Signed-off-by: Gang Pu <pugangxa@cn.ibm.com>

Image tages already changed so need change value for kind cluster. In my development it always pulls the image with "master" tag now.