### PR TITLE
doc: add link to the doc of DDC

### DIFF
--- a/site/docs/reference/ddc.md
+++ b/site/docs/reference/ddc.md
@@ -5,7 +5,7 @@
 The **Data Distribution Controller** (DDC) handles the movement of data between data stores.
 Fybrik uses the DDC to perform an action called "implicit copy", i.e. the movement
 of a data set from one data store to another with possibly some unitary transform applied
-to that data set. It corresponds to Step 8 in the Architecture Document (Add a link here)
+to that data set. It corresponds to Step 8 in the [Architecture](../concepts/architecture.md).
 
 Data can be copied from data store to data store in a large variety of different ways, depending on the types of the data store (e.g. COS, Relational DB) and nature of the data capture (Streamed, Snapshot).
 This document defines the functionality as well as the boundary conditions of the data distribution controller.


### PR DESCRIPTION
this adds link of "Architecture" to the doc "Data Distribution Controller"