### PR TITLE
Adding description for REST APIs in documentation

### DIFF
--- a/connectors/api/datacatalog.spec.yaml
+++ b/connectors/api/datacatalog.spec.yaml
@@ -9,7 +9,7 @@ servers:
 paths:
   /getAssetInfo:
       post:
-        summary: getAssetInfo
+        summary: This REST API gets data asset information from the data catalog configured in fybrik for the data sets indicated in FybrikApplication yaml
         operationId: getAssetInfo
         parameters:
           - in: header

--- a/connectors/api/policymanager.spec.yaml
+++ b/connectors/api/policymanager.spec.yaml
@@ -9,7 +9,7 @@ servers:
 paths:
   /getPoliciesDecisions:
     post:
-      summary: getPoliciesDecisions
+      summary: This REST API gets data governance decisions for the data sets indicated in FybrikApplication yaml based on the context indicated
       operationId: getPoliciesDecisions
       parameters:
         - in: header

--- a/site/Makefile
+++ b/site/Makefile
@@ -35,4 +35,4 @@ generate-connectors-docs:
 .PHONY: run
 run: generate
 	@echo "\nServing on http://127.0.0.1:8000/"
-	mkdocs serve --quiet
+	python -m mkdocs serve --quiet

--- a/site/Makefile
+++ b/site/Makefile
@@ -35,4 +35,4 @@ generate-connectors-docs:
 .PHONY: run
 run: generate
 	@echo "\nServing on http://127.0.0.1:8000/"
-	python -m mkdocs serve --quiet
+	mkdocs serve --quiet

--- a/site/docs/reference/connectors-datacatalog/Apis/DefaultApi.md
+++ b/site/docs/reference/connectors-datacatalog/Apis/DefaultApi.md
@@ -4,14 +4,14 @@ All URIs are relative to *https://localhost:8080*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**getAssetInfo**](DefaultApi.md#getAssetInfo) | **POST** /getAssetInfo | getAssetInfo
+[**getAssetInfo**](DefaultApi.md#getAssetInfo) | **POST** /getAssetInfo | This REST API gets data asset information from the data catalog configured in fybrik for the data sets indicated in FybrikApplication yaml
 
 
 <a name="getAssetInfo"></a>
 ## **getAssetInfo**
 > GetAssetResponse getAssetInfo(X-Request-Datacatalog-CredGetAssetRequest)
 
-getAssetInfo
+This REST API gets data asset information from the data catalog configured in fybrik for the data sets indicated in FybrikApplication yaml
 
 
 ### Parameters

--- a/site/docs/reference/connectors-datacatalog/README.md
+++ b/site/docs/reference/connectors-datacatalog/README.md
@@ -7,7 +7,7 @@ All URIs are relative to *https://localhost:8080*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
-*DefaultApi* | [**getAssetInfo**](Apis/DefaultApi.md#getassetinfo) | **POST** /getAssetInfo | getAssetInfo
+*DefaultApi* | [**getAssetInfo**](Apis/DefaultApi.md#getassetinfo) | **POST** /getAssetInfo | This REST API gets data asset information from the data catalog configured in fybrik for the data sets indicated in FybrikApplication yaml
 
 
 <a name="documentation-for-models"></a>

--- a/site/docs/reference/connectors-policymanager/Apis/DefaultApi.md
+++ b/site/docs/reference/connectors-policymanager/Apis/DefaultApi.md
@@ -4,14 +4,14 @@ All URIs are relative to *https://localhost:8080*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**getPoliciesDecisions**](DefaultApi.md#getPoliciesDecisions) | **POST** /getPoliciesDecisions | getPoliciesDecisions
+[**getPoliciesDecisions**](DefaultApi.md#getPoliciesDecisions) | **POST** /getPoliciesDecisions | This REST API gets data governance decisions for the data sets indicated in FybrikApplication yaml based on the context indicated
 
 
 <a name="getPoliciesDecisions"></a>
 ## **getPoliciesDecisions**
 > GetPolicyDecisionsResponse getPoliciesDecisions(X-Request-CredGetPolicyDecisionsRequest)
 
-getPoliciesDecisions
+This REST API gets data governance decisions for the data sets indicated in FybrikApplication yaml based on the context indicated
 
 
 ### Parameters

--- a/site/docs/reference/connectors-policymanager/README.md
+++ b/site/docs/reference/connectors-policymanager/README.md
@@ -7,7 +7,7 @@ All URIs are relative to *https://localhost:8080*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
-*DefaultApi* | [**getPoliciesDecisions**](Apis/DefaultApi.md#getpoliciesdecisions) | **POST** /getPoliciesDecisions | getPoliciesDecisions
+*DefaultApi* | [**getPoliciesDecisions**](Apis/DefaultApi.md#getpoliciesdecisions) | **POST** /getPoliciesDecisions | This REST API gets data governance decisions for the data sets indicated in FybrikApplication yaml based on the context indicated
 
 
 <a name="documentation-for-models"></a>


### PR DESCRIPTION
This PR adds description to REST APIs in the documentation based on [comments](https://github.com/fybrik/fybrik/pull/1068#discussion_r778607497) given by @simanadler . The documentation looks as follows: 
![image](https://user-images.githubusercontent.com/59818576/148916171-f360932f-4ff0-488c-a200-69e9d73294eb.png)

![image](https://user-images.githubusercontent.com/59818576/148916197-be91b2eb-3f02-4b8a-a664-22384eba74e9.png)

Signed-off-by: Rohith D Vallam <rovallam@in.ibm.com>