### PR TITLE
only include docker sidecar when required

### DIFF
--- a/pipeline/tasks/make-dind.yaml
+++ b/pipeline/tasks/make-dind.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: make
+  name: make-dind
 spec:
   description: This Task is Golang task to test Go projects.
   params:
@@ -95,6 +95,9 @@ spec:
       cd $(params.context)
       $(params.env_vars) make $(params.target) $(params.flags) $(params.packages)
     workingDir: $(workspaces.source.path)
+    volumeMounts:
+    - mountPath: /var/run/
+      name: dind-socket
   - image: $(params.image)
     name: docker-namespace-to-results
     resources: {}
@@ -103,5 +106,22 @@ spec:
     name: docker-hostname-to-results
     resources: {}
     script: echo -n $(params.docker-hostname) > /tekton/results/docker-hostname
+  sidecars:
+  - image: docker:18.05-dind
+    name: server
+    securityContext:
+      privileged: true
+    volumeMounts:
+      - mountPath: /var/lib/docker
+        name: dind-storage
+      - mountPath: /var/run/
+        name: dind-socket
+      - name: $(workspaces.source.volume)
+        mountPath: $(workspaces.source.path)
   workspaces:
   - name: source
+  volumes:
+  - name: dind-storage
+    emptyDir: {}
+  - name: dind-socket
+    emptyDir: {}


### PR DESCRIPTION
Default make task will not include the docker sidecar, to reduce likelihood of docker being slow to respond and causing an exception

Signed-off-by: Nicholas Goracke <ngoracke@us.ibm.com>