### PR TITLE
Fix Vault's “claim iss is invalid” error in Kubernetes 1.21. 

### DIFF
--- a/charts/vault/templates/post-pod-creation-cm.yaml
+++ b/charts/vault/templates/post-pod-creation-cm.yaml
@@ -10,7 +10,7 @@ data:
 {{- if semverCompare "<1.21-0" .Capabilities.KubeVersion.Version }}
       vault write auth/kubernetes/config kubernetes_host="https://kubernetes.default.svc:443"
 {{- else }}
-      vault write auth/kubernetes/config issuer="https://kubernetes.default.svc" kubernetes_host="https://kubernetes.default.svc:443"
+      vault write auth/kubernetes/config issuer="https://kubernetes.default.svc" kubernetes_host="https://kubernetes.default.svc:443" disable_iss_validation=true
 {{- end }}
       # register and enable secret engine
       SHA256=$(sha256sum /usr/local/libexec/vault/vault-plugin-secrets-kubernetes-reader | cut -d ' ' -f1)


### PR DESCRIPTION
This PR adds `disable_iss_validation=true` when configuring Kubernetes auth method in Vault. Following what is written in [here](https://www.vaultproject.io/docs/auth/kubernetes#discovering-the-service-account-issuer): `disable_iss_validation=true is the new recommended value for all versions of Vault`. and [here](https://www.vaultproject.io/docs/auth/kubernetes#kubernetes-auth-method): `If you are upgrading to Kubernetes v1.21+, ensure the config option disable_iss_validation is set to true. `

Closes #1175 