### PR TITLE
Fixes: Missing details in log when module is not chosen by the Fybrik…

### DIFF
--- a/manager/controllers/app/plotter_generator.go
+++ b/manager/controllers/app/plotter_generator.go
@@ -142,23 +142,22 @@ func (p *PlotterGenerator) AddFlowInfoForAsset(item DataInfo, appContext *app.Fy
 
 	// DataStore for destination will be determined if an implicit copy is required
 	var sinkDataStore *app.DataStore
-	dataitem := item.Context.CatalogService + "/" + item.Context.DataSetID
 
 	solutions := p.FindPaths(&item, appContext)
 	// No data path found for the asset
 	if len(solutions) == 0 {
 		msg := "Deployed modules do not provide the functionality required to construct a data path"
-		p.Log.Error().Str(logging.DATASETID, dataitem).Msg(msg)
+		p.Log.Error().Str(logging.DATASETID, item.Context.DataSetID).Msg(msg)
 		logging.LogStructure("Data Item Context", item, p.Log, true, true)
 		logging.LogStructure("Module Map", p.Modules, p.Log, true, true)
-		return errors.New(msg + " for " + dataitem)
+		return errors.New(msg + " for " + item.Context.DataSetID)
 	}
-	p.Log.Trace().Str(logging.DATASETID, dataitem).Msg("Generating a plotter")
+	p.Log.Trace().Str(logging.DATASETID, item.Context.DataSetID).Msg("Generating a plotter")
 	selection := solutions[0]
 	datasetID := item.Context.DataSetID
 	for _, element := range selection.DataPath {
 		moduleCapability := element.Module.Spec.Capabilities[element.CapabilityIndex]
-		p.Log.Trace().Str(logging.DATASETID, dataitem).Msgf("Adding module for %s", moduleCapability.Capability)
+		p.Log.Trace().Str(logging.DATASETID, item.Context.DataSetID).Msgf("Adding module for %s", moduleCapability.Capability)
 		actions := element.Actions
 		template := app.Template{
 			Name: string(moduleCapability.Capability),
@@ -182,7 +181,7 @@ func (p *PlotterGenerator) AddFlowInfoForAsset(item DataInfo, appContext *app.Fy
 		if !element.Sink.Virtual {
 			// allocate storage and create a temoprary asset
 			if sinkDataStore, err = p.GetCopyDestination(item, element.Sink.Connection, element.StorageAccountRegion); err != nil {
-				p.Log.Error().Err(err).Str(logging.DATASETID, dataitem).Msg("Storage allocation for copy failed")
+				p.Log.Error().Err(err).Str(logging.DATASETID, item.Context.DataSetID).Msg("Storage allocation for copy failed")
 				return err
 			}
 			copyAssetID := datasetID + "-copy"

--- a/manager/controllers/app/plotter_generator.go
+++ b/manager/controllers/app/plotter_generator.go
@@ -145,9 +145,11 @@ func (p *PlotterGenerator) AddFlowInfoForAsset(item DataInfo, appContext *app.Fy
 	dataitem := item.Context.CatalogService + "/" + item.Context.DataSetID
 
 	solutions := p.FindPaths(&item, appContext)
+	// No data path found for the asset
 	if len(solutions) == 0 {
 		msg := "Deployed modules do not provide the functionality required to construct a data path"
 		p.Log.Error().Str(logging.DATASETID, dataitem).Msg(msg)
+		logging.LogStructure("Data Item Context", item, p.Log, true, true)
 		logging.LogStructure("Module Map", p.Modules, p.Log, true, true)
 		return errors.New(msg + " for " + dataitem)
 	}


### PR DESCRIPTION
Fixes #1168
Makes the error message clearer when a data plane can't be constructed for a given data set. Also prints the catalogID/datasetID and its context as well as the deployed modules to the log.

Signed-off-by: simanadler <sima@il.ibm.com>