### PR TITLE
Avoid publish images and charts with `latest` tag.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,9 +206,3 @@ jobs:
       env:
         DOCKER_PUBLIC_TAGNAME:  ${{ steps.version.outputs.version }}
       run: make docker-retag-and-push-public && make helm-push-public
-    - name: Publish latest image tag on push tag event
-      if: github.event_name != 'pull_request' && steps.version.outputs.push_tag_event == 'true'
-      env:
-        DOCKER_PUBLIC_TAGNAME: 'latest'
-        HELM_TAG: '0.0.0-latest'
-      run: make docker-retag-and-push-public && make helm-push-public


### PR DESCRIPTION
This PR removes from the `build.yaml` workflow the section which publishes docker images and charts with `latest` tag upon pushing a new tag.

The `latest` tag should hold the latest release however as it is implemented now it could hold a release that was published last.