### PR TITLE
Allow S3 endpoint containing the scheme

### DIFF
--- a/manager/controllers/app/plotter_generator.go
+++ b/manager/controllers/app/plotter_generator.go
@@ -5,7 +5,6 @@ package app
 
 import (
 	"bytes"
-	"net/url"
 	"strings"
 	"text/template"
 
@@ -67,19 +66,12 @@ func (p *PlotterGenerator) GetCopyDestination(item DataInfo, destinationInterfac
 		return nil, err
 	}
 
-	// S3 endpoint should not include the url scheme only the host name
-	// thus ignoring it if such exists.
-	url, err := url.Parse(bucket.Endpoint)
-	if err != nil {
-		return nil, err
-	}
-
 	connection := taxonomy.Connection{
 		Name: "s3",
 		AdditionalProperties: serde.Properties{
 			Items: map[string]interface{}{
 				"s3": map[string]interface{}{
-					"endpoint":   url.Host,
+					"endpoint":   bucket.Endpoint,
 					"bucket":     bucket.Name,
 					"object_key": genObjectKeyName,
 				},

--- a/pkg/connectors/protos/dataset_details.proto
+++ b/pkg/connectors/protos/dataset_details.proto
@@ -38,7 +38,7 @@ message Db2DataStore {
 }
 
 message S3DataStore {
-    string endpoint = 1;    // endpoint should contain only the host name without the scheme i.e., "s3.eu-gb.cloud-object-storage.appdomain.cloud"
+    string endpoint = 1;
     string bucket = 2;
     string object_key = 3; //can be object name or the prefix for dataset
     string region = 4;     // WKC does not return it, it will stay empty in our case!!!

--- a/site/docs/reference/connectors.md
+++ b/site/docs/reference/connectors.md
@@ -326,7 +326,7 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| endpoint | [string](#string) |  | endpoint should contain only the host name without the scheme i.e., "s3.eu-gb.cloud-object-storage.appdomain.cloud" |
+| endpoint | [string](#string) |  |  |
 | bucket | [string](#string) |  |  |
 | object_key | [string](#string) |  | can be object name or the prefix for dataset |
 | region | [string](#string) |  | WKC does not return it, it will stay empty in our case!!! |


### PR DESCRIPTION
Fixes #1192

Set the value of `s3['endpoint']` to `bucket.Endpoint` instead of `url.Host` , to contain the url scheme.