### PR TITLE
Update fybrik chart to support cert-manager/v1 api version

### DIFF
--- a/charts/fybrik/templates/_helpers.tpl
+++ b/charts/fybrik/templates/_helpers.tpl
@@ -98,13 +98,17 @@ true
 
 {{/*
 Detect the version of cert manager crd that is installed
-Defaults to cert-manager.io/v1alpha2 
+Defaults to cert-manager.io/v1
 */}}
 {{- define "fybrik.certManagerApiVersion" -}}
-{{- if (.Capabilities.APIVersions.Has "certmanager.k8s.io/v1alpha1") -}}
-certmanager.k8s.io/v1alpha1
-{{- else  -}}
+{{- if .Capabilities.APIVersions.Has "cert-manager.io/v1beta1" -}}
+cert-manager.io/v1beta1
+{{- else if .Capabilities.APIVersions.Has "cert-manager.io/v1alpha2" -}}
 cert-manager.io/v1alpha2
+{{- else if .Capabilities.APIVersions.Has "certmanager.k8s.io/v1alpha1" -}}
+certmanager.k8s.io/v1alpha1
+{{- else -}}
+cert-manager.io/v1
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Part of #1216 and #1207 

This PR updates fybrik resources to work with `cert-manager.io/v1`.

Signed-off-by: Revital Sur <eres@il.ibm.com>
Co-authored-by: Mohammad Nassar <mohammad.nassar@ibm.com>