### PR TITLE
change to PAT base pull requests

### DIFF
--- a/.github/workflows/operate-first-publish.yaml
+++ b/.github/workflows/operate-first-publish.yaml
@@ -31,18 +31,12 @@ jobs:
           rm ./*.yaml
           popd
           rsync -a --include='*/' --include='*.yaml' --exclude='*' fybrik-repo/integration/operate-first/ operate-first-repo/cluster-scope/base
-      - uses: tibdex/github-app-token@v1
-        id: generate-token
-        with:
-          app_id: ${{ secrets.FYBRIK_BOT_APP_ID }}
-          private_key: ${{ secrets.FYBRIK_BOT_PRIVATE_KEY }}
-          repository: fybrik/operate-first-apps
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
           path: operate-first-repo
           signoff: true
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ secrets.PAT }}
           push-to-fork: fybrik/operate-first-apps
           title: 'Update Fybrik manifests to new release'
           commit-message: Update Fybrik cluster-scoped resources for Operate First


### PR DESCRIPTION
Bot auto-generated token cannot create pull request to operate-first-app. 
Replace it by a PAT
Signed-off-by: Alexey Roytman <roytman@il.ibm.com>