### PR TITLE
Fix asset-crd version in charts/fybrik-crd/Chart.yaml

### DIFF
--- a/charts/fybrik-crd/Chart.yaml
+++ b/charts/fybrik-crd/Chart.yaml
@@ -14,5 +14,5 @@ version: 0.6.2
 appVersion: 0.6.2
 dependencies:
   - name: asset-crd
-    version: 0.0.0
+    version: 0.6.2
     condition: asset-crd.enabled


### PR DESCRIPTION
This PR fixes asset-crd version in charts/fybrik-crd/Chart.yaml.
It is not updated in [release_branch.yaml](https://github.com/fybrik/fybrik/blob/master/.github/workflows/release-branch.yaml) workflow because the change which contains the version was merged after the release branch was created.