### PR TITLE
Add more information to the taxonomy validation error

### DIFF
--- a/pkg/taxonomy/validate/resource.go
+++ b/pkg/taxonomy/validate/resource.go
@@ -23,7 +23,7 @@ func TaxonomyCheck(resourceJSON []byte, schemaPath string) ([]*field.Error, erro
 	documentLoader := gojsonschema.NewBytesLoader(resourceJSON)
 	result, err := gojsonschema.Validate(taxonomyLoader, documentLoader)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not validate resource against the provided schema")
+		return nil, errors.Wrap(err, "could not validate resource against the provided schema, check files at "+filepath.Dir(schemaPath))
 	}
 
 	// Return validation errors


### PR DESCRIPTION
When taxonomy schema files are bad formatting, taxonomy validation fails with some kind of cryptic message, e.g. 
`could not validate resource against the provided schema invalid character '\n' in string literal`.

It happens not due to wrong checking object, e.g. fybrik application, but due to wrong taxonomy files, wrong JSON format. Therefore, the PR point to check the files. 
 
Signed-off-by: Alexey Roytman <roytman@il.ibm.com>