### PR TITLE
Add the enabled flag for vault

### DIFF
--- a/charts/fybrik/kind-control.values.yaml
+++ b/charts/fybrik/kind-control.values.yaml
@@ -27,6 +27,7 @@ cluster:
 # Configuration when deploying to a coordinator cluster.
 coordinator:
   vault:
+    enabled: true
     # vault service in local setup is exposed via nodeport
     address: http://control-control-plane:31752
 

--- a/charts/fybrik/templates/cluster-metadata-config.yaml
+++ b/charts/fybrik/templates/cluster-metadata-config.yaml
@@ -9,5 +9,7 @@ data:
   ClusterName: {{ required "cluster name must be set" .Values.cluster.name | quote }}
   Region: {{ required "cluster region must be set" .Values.cluster.region | quote }}
   Zone: {{ .Values.cluster.zone | quote }}
+  {{- if .Values.coordinator.vault.enabled }}
   VaultAuthPath: {{ required "vaultAuthPath must be set" .Values.cluster.vaultAuthPath | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/fybrik/templates/fybrik-config.yaml
+++ b/charts/fybrik/templates/fybrik-config.yaml
@@ -14,7 +14,9 @@ data:
   CATALOG_CONNECTOR_URL: {{ .Values.coordinator.catalogConnectorURL | default (printf "http://%s-connector:80" .Values.coordinator.catalog) | quote }}
   MAIN_POLICY_MANAGER_NAME: {{ .Values.coordinator.policyManager | quote }}
   MAIN_POLICY_MANAGER_CONNECTOR_URL: {{ .Values.coordinator.policyManagerConnectorURL | default (printf "http://%s-connector:80" .Values.coordinator.policyManager) | quote }}
+  {{- if .Values.coordinator.vault.enabled }}
   VAULT_ADDRESS: {{ tpl .Values.coordinator.vault.address . | quote }}
   VAULT_MODULES_ROLE: "module" # temporary
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/fybrik/templates/fybrik-config.yaml
+++ b/charts/fybrik/templates/fybrik-config.yaml
@@ -15,6 +15,7 @@ data:
   MAIN_POLICY_MANAGER_NAME: {{ .Values.coordinator.policyManager | quote }}
   MAIN_POLICY_MANAGER_CONNECTOR_URL: {{ .Values.coordinator.policyManagerConnectorURL | default (printf "http://%s-connector:80" .Values.coordinator.policyManager) | quote }}
   {{- if .Values.coordinator.vault.enabled }}
+  VAULT_ENABLED: "true"
   VAULT_ADDRESS: {{ tpl .Values.coordinator.vault.address . | quote }}
   VAULT_MODULES_ROLE: "module" # temporary
   {{- end }}

--- a/charts/fybrik/templates/vault-credentials.yaml
+++ b/charts/fybrik/templates/vault-credentials.yaml
@@ -1,4 +1,5 @@
 {{- if include "fybrik.isEnabled" (tuple .Values.manager.enabled .Values.coordinator.enabled) }}
+{{- if .Values.coordinator.vault.enabled }}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -8,4 +9,5 @@ data:
   {{ if .Values.coordinator.vault.login.token }}
   VAULT_TOKEN: {{ .Values.coordinator.vault.login.token | b64enc }}
   {{ end }}
+{{- end }}
 {{- end }}

--- a/charts/fybrik/values.yaml
+++ b/charts/fybrik/values.yaml
@@ -79,7 +79,9 @@ coordinator:
 
   # Configure the vault instance to be used by the coordinator manager
   vault:
-    # if you don't plan to use Vault, set it to false. If it is false, you can remove all other entries below
+    # WARNING: it's an advance feature, set it to "false", if you all your modules and connectors do not require getting
+    # credentials to from Fybrik.
+    # If it is "false", you can remove all other entries below.
     enabled: true
     # Set to the Vault address.
     address: "http://vault.{{ .Release.Namespace }}:8200"

--- a/charts/fybrik/values.yaml
+++ b/charts/fybrik/values.yaml
@@ -79,7 +79,9 @@ coordinator:
 
   # Configure the vault instance to be used by the coordinator manager
   vault:
-    # Set to the Vault address. 
+    # if you don't plan to use Vault, set it to false. If it is false, you can remove all other entries below
+    enabled: true
+    # Set to the Vault address.
     address: "http://vault.{{ .Release.Namespace }}:8200"
     # Login method to Vault
     login:

--- a/charts/fybrik/values.yaml
+++ b/charts/fybrik/values.yaml
@@ -79,8 +79,8 @@ coordinator:
 
   # Configure the vault instance to be used by the coordinator manager
   vault:
-    # WARNING: it's an advance feature, set it to "false", if you all your modules and connectors do not require getting
-    # credentials to from Fybrik.
+    # WARNING: it's an advanced feature, set it to "false" if all your modules and connectors do not require getting
+    # credentials from Fybrik.
     # If it is "false", you can remove all other entries below.
     enabled: true
     # Set to the Vault address.

--- a/manager/controllers/app/policy_compiler_interface.go
+++ b/manager/controllers/app/policy_compiler_interface.go
@@ -77,7 +77,11 @@ func LookupPolicyDecisions(datasetID string, policyManager connectors.PolicyMana
 
 	var creds string
 	if appContext.Application.Spec.SecretRef != "" {
-		creds = utils.GetVaultAddress() + vault.PathForReadingKubeSecret(appContext.Application.Namespace, appContext.Application.Spec.SecretRef)
+		if !utils.IsVaultEnabled() {
+			appContext.Log.Error().Str("SecretRef", appContext.Application.Spec.SecretRef).Msg("SecretRef defined [%s], but vault is disabled")
+		} else {
+			creds = utils.GetVaultAddress() + vault.PathForReadingKubeSecret(appContext.Application.Namespace, appContext.Application.Spec.SecretRef)
+		}
 	}
 
 	openapiResp, err := policyManager.GetPoliciesDecisions(openapiReq, creds)

--- a/manager/controllers/utils/configuration.go
+++ b/manager/controllers/utils/configuration.go
@@ -15,7 +15,7 @@ import (
 // Attributes that are defined in a config map or the runtime environment
 const (
 	CatalogConnectorServiceAddressKey string = "CATALOG_CONNECTOR_URL"
-	VaultEnabled                      string = "VAULT_ENABLED"
+	VaultEnabledKey                   string = "VAULT_ENABLED"
 	VaultAddressKey                   string = "VAULT_ADDRESS"
 	VaultModulesRoleKey               string = "VAULT_MODULES_ROLE"
 	EnableWebhooksKey                 string = "ENABLE_WEBHOOKS"
@@ -39,7 +39,7 @@ func GetSystemNamespace() string {
 }
 
 func IsVaultEnabled() bool {
-	v := os.Getenv(VaultEnabled)
+	v := os.Getenv(VaultEnabledKey)
 	return v == "true"
 }
 

--- a/manager/controllers/utils/configuration.go
+++ b/manager/controllers/utils/configuration.go
@@ -15,6 +15,7 @@ import (
 // Attributes that are defined in a config map or the runtime environment
 const (
 	CatalogConnectorServiceAddressKey string = "CATALOG_CONNECTOR_URL"
+	VaultEnabled                      string = "VAULT_ENABLED"
 	VaultAddressKey                   string = "VAULT_ADDRESS"
 	VaultModulesRoleKey               string = "VAULT_MODULES_ROLE"
 	EnableWebhooksKey                 string = "ENABLE_WEBHOOKS"
@@ -35,6 +36,11 @@ func GetSystemNamespace() string {
 		}
 	}
 	return DefaultControllerNamespace
+}
+
+func IsVaultEnabled() bool {
+	v := os.Getenv(VaultEnabled)
+	return v == "true"
 }
 
 // GetModulesRole returns the modules assigned authentication role for accessing dataset credentials

--- a/manager/controllers/utils/vault.go
+++ b/manager/controllers/utils/vault.go
@@ -11,6 +11,9 @@ import (
 // It is of the form v1/auth/<auth path>/login
 // TODO - Different credentials for different data flows (read, write, delete)
 func GetAuthPath(authPath string) string {
+	if authPath == "" {
+		return ""
+	}
 	fullAuthPath := fmt.Sprintf("/v1/auth/%s/login", authPath)
 	return fullAuthPath
 }


### PR DESCRIPTION
Some deployments do not use Vault, so this PR allows skipping the vault configuration setting.

Part of #1280 
Signed-off-by: Alexey Roytman <roytman@il.ibm.com>