### PR TITLE
Plotter reports ready when a blueprint can't be created

### DIFF
--- a/manager/controllers/app/plotter_controller.go
+++ b/manager/controllers/app/plotter_controller.go
@@ -419,6 +419,7 @@ func (r *PlotterReconciler) reconcile(plotter *app.Plotter) (ctrl.Result, []erro
 				blueprint.Labels[key] = val
 			}
 			err := r.ClusterManager.CreateBlueprint(cluster, blueprint)
+			isReady = false
 			if err != nil {
 				errorCollection = append(errorCollection, err)
 				log.Error().Err(err).Str(logging.CLUSTER, cluster).Str(logging.ACTION, logging.CREATE).Msg("Could not create blueprint for cluster")
@@ -427,7 +428,6 @@ func (r *PlotterReconciler) reconcile(plotter *app.Plotter) (ctrl.Result, []erro
 			}
 
 			plotter.Status.Blueprints[cluster] = app.CreateMetaBlueprintWithoutState(blueprint)
-			isReady = false
 			r.setPlotterAssetsReadyStateToFalse(assetToStatusMap, &blueprintSpec, "Blueprint just created")
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Shlomit Koyfman <shlomitk@il.ibm.com>

Fixes https://github.com/fybrik/fybrik/issues/1210

When a new blueprint is created, plotter controller sets the readiness state to false. This was done after a successful creation only, which caused the error. This PR sets the readiness state to false before checking whether the creation was successful or not.