### PR TITLE
Add unit-test for write flow in fybrikapplication_controller_unit_tes…

### DIFF
--- a/manager/controllers/app/fybrikapplication_controller_unit_test.go
+++ b/manager/controllers/app/fybrikapplication_controller_unit_test.go
@@ -1389,7 +1389,7 @@ func TestReadAndTransform(t *testing.T) {
 	g.Expect(plotter.Spec.Flows[0].SubFlows[0].Steps[0]).To(gomega.HaveLen(2))
 }
 
-func TestWriteIsNewDataSetFalse(t *testing.T) {
+func TestWriteRegisteredAsset(t *testing.T) {
 	t.Parallel()
 	g := gomega.NewGomegaWithT(t)
 	// Set the logger to development mode for verbose logs.
@@ -1401,21 +1401,6 @@ func TestWriteIsNewDataSetFalse(t *testing.T) {
 	}
 	application := &app.FybrikApplication{}
 	g.Expect(readObjectFromFile("../../testdata/unittests/fybrikapplication-write-AssetExists.yaml", application)).NotTo(gomega.HaveOccurred())
-	application.Spec.Data[0] = app.DataContext{
-		DataSetID:    "s3/original-dataset",
-		Flow:         taxonomy.ReadFlow,
-		Requirements: app.DataRequirements{Interface: app.InterfaceDetails{Protocol: app.ArrowFlight}},
-	}
-	application.Spec.Data[1] = app.DataContext{
-		DataSetID:    "s3/new-dataset",
-		Flow:         taxonomy.WriteFlow,
-		Requirements: app.DataRequirements{Interface: app.InterfaceDetails{Protocol: app.ArrowFlight}},
-	}
-	application.Spec.Data[2] = app.DataContext{
-		DataSetID:    "s3/new-dataset",
-		Flow:         taxonomy.ReadFlow,
-		Requirements: app.DataRequirements{Interface: app.InterfaceDetails{Protocol: app.ArrowFlight}},
-	}
 	application.SetGeneration(1)
 	application.SetUID("17")
 	// Objects to track in the fake client.
@@ -1450,6 +1435,7 @@ func TestWriteIsNewDataSetFalse(t *testing.T) {
 	g.Expect(err).To(gomega.BeNil(), "Cannot fetch fybrikapplication")
 	g.Expect(getErrorMessages(application)).To(gomega.BeEmpty())
 	// check plotter creation
+	g.Expect(application.Status.AssetStates).To(gomega.HaveLen(2))
 	g.Expect(application.Status.Generated).ToNot(gomega.BeNil())
 	readOriginalDatalEndpoint := application.Status.AssetStates[application.Spec.Data[0].DataSetID].Endpoint
 	g.Expect(readOriginalDatalEndpoint).To(gomega.Not(gomega.BeNil()))
@@ -1474,5 +1460,5 @@ func TestWriteIsNewDataSetFalse(t *testing.T) {
 	err = cl.Get(context.Background(), plotterObjectKey, plotter)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	g.Expect(plotter.Spec.Assets).To(gomega.HaveLen(2))
-	g.Expect(plotter.Spec.Templates).To(gomega.HaveLen(2)) // expect two template: one for read and one for write
+	g.Expect(plotter.Spec.Templates).To(gomega.HaveLen(2)) // expect two templates: one for read and one for write
 }

--- a/manager/controllers/app/fybrikapplication_controller_unit_test.go
+++ b/manager/controllers/app/fybrikapplication_controller_unit_test.go
@@ -1451,16 +1451,21 @@ func TestWriteIsNewDataSetFalse(t *testing.T) {
 	g.Expect(getErrorMessages(application)).To(gomega.BeEmpty())
 	// check plotter creation
 	g.Expect(application.Status.Generated).ToNot(gomega.BeNil())
-	readOriginaDatalEndpoint := application.Status.AssetStates[application.Spec.Data[0].DataSetID].Endpoint
-	g.Expect(readOriginaDatalEndpoint).To(gomega.Not(gomega.BeNil()))
+	readOriginalDatalEndpoint := application.Status.AssetStates[application.Spec.Data[0].DataSetID].Endpoint
+	g.Expect(readOriginalDatalEndpoint).To(gomega.Not(gomega.BeNil()))
+	readOriginalConnectionMap := readOriginalDatalEndpoint.AdditionalProperties.Items
+	g.Expect(readOriginalConnectionMap).To(gomega.HaveKey("fybrik-arrow-flight"))
+	readOriginalDataConfig := readOriginalConnectionMap["fybrik-arrow-flight"].(map[string]interface{})
+	g.Expect(readOriginalDataConfig["hostname"]).To(gomega.Equal("read-write-module"))
+
+	g.Expect(application.Status.Generated).ToNot(gomega.BeNil())
 	readNewDataEndpoint := application.Status.AssetStates[application.Spec.Data[2].DataSetID].Endpoint
 	g.Expect(readNewDataEndpoint).To(gomega.Not(gomega.BeNil()))
-	readOriginaDataConnectionMap := readNewDataEndpoint.AdditionalProperties.Items
-	g.Expect(readOriginaDataConnectionMap).To(gomega.HaveKey("fybrik-arrow-flight"))
-	readOriginaDataConfig := readOriginaDataConnectionMap["fybrik-arrow-flight"].(map[string]interface{})
-	g.Expect(readOriginaDataConfig["hostname"]).To(gomega.Equal("read-write-module"))
-	readNewDataConfig := readOriginaDataConnectionMap["fybrik-arrow-flight"].(map[string]interface{})
+	readNewConnectionMap := readNewDataEndpoint.AdditionalProperties.Items
+	g.Expect(readNewConnectionMap).To(gomega.HaveKey("fybrik-arrow-flight"))
+	readNewDataConfig := readNewConnectionMap["fybrik-arrow-flight"].(map[string]interface{})
 	g.Expect(readNewDataConfig["hostname"]).To(gomega.Equal("read-write-module"))
+
 	plotterObjectKey := types.NamespacedName{
 		Namespace: application.Status.Generated.Namespace,
 		Name:      application.Status.Generated.Name,
@@ -1469,5 +1474,5 @@ func TestWriteIsNewDataSetFalse(t *testing.T) {
 	err = cl.Get(context.Background(), plotterObjectKey, plotter)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	g.Expect(plotter.Spec.Assets).To(gomega.HaveLen(2))
-	g.Expect(plotter.Spec.Templates).To(gomega.HaveLen(2)) // expect one template
+	g.Expect(plotter.Spec.Templates).To(gomega.HaveLen(2)) // expect two template: one for read and one for write
 }

--- a/manager/testdata/unittests/fybrikapplication-write-AssetExists.yaml
+++ b/manager/testdata/unittests/fybrikapplication-write-AssetExists.yaml
@@ -1,0 +1,35 @@
+# Copyright 2020 IBM Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: app.fybrik.io/v1alpha1
+kind: FybrikApplication
+metadata:
+  name: read-write-test
+  namespace: default
+  labels:
+    app: notebook
+spec:
+  selector:
+    clusterName: thegreendragon
+    workloadSelector:
+      matchLabels:
+        app: notebook
+  appInfo:
+    intent: Fraud Detection
+    role: Security
+  data:
+  - dataSetID: "s3/original-dataset"
+    flow: read
+    requirements:
+      interface:
+        protocol: fybrik-arrow-flight
+  - dataSetID: "s3/new-dataset"
+    flow: write
+    requirements:
+      interface:
+        protocol: fybrik-arrow-flight
+  - dataSetID: "s3/new-dataset"
+    flow: read
+    requirements:
+      interface:
+        protocol: fybrik-arrow-flight

--- a/manager/testdata/unittests/module-read-write-parquet.yaml
+++ b/manager/testdata/unittests/module-read-write-parquet.yaml
@@ -1,0 +1,41 @@
+# Copyright 2020 IBM Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: app.fybrik.io/v1alpha1
+kind: FybrikModule
+metadata:
+  name: read-write-parquet
+  namespace: fybrik-system
+spec:
+  chart:
+    name:  ghcr.io/fybrik/fybrik-template:0.1.0
+  type: service
+  capabilities:
+    - capability: read
+      api:
+        connection:
+          name: fybrik-arrow-flight
+          fybrik-arrow-flight:
+            hostname: read-write-module
+            port: 80
+            scheme: grpc
+      supportedInterfaces:
+      - source:
+          protocol: s3
+          dataformat: parquet
+      actions:
+      - name: RedactAction
+      - name: RemoveAction
+
+    - capability: write
+      api:
+        connection:
+          name: fybrik-arrow-flight
+          fybrik-arrow-flight:
+            hostname: read-write-module
+            port: 80
+            scheme: grpc
+      supportedInterfaces:
+      - sink:
+          protocol: s3
+          dataformat: parquet


### PR DESCRIPTION
This PR adds unit test for the write flow where `IsNewDataSet` flag is false which means that the asset is already exists in the catalog.