### PR TITLE
Additional restrictions on capabilities' deployment in out-of-the-box policies

### DIFF
--- a/charts/fybrik/files/adminconfig/default_policies.rego
+++ b/charts/fybrik/files/adminconfig/default_policies.rego
@@ -30,7 +30,7 @@ config[{"capability": "delete", "decision": decision}] {
     decision := {"policy": policy, "deploy": "True"}
 }
 
-# do not deploy copy in scenarios different than read or copy
+# do not deploy copy in scenarios different from read or copy
 config[{"capability": "copy", "decision": decision}] {
     input.request.usage != "read"
     input.request.usage != "copy"

--- a/charts/fybrik/files/adminconfig/default_policies.rego
+++ b/charts/fybrik/files/adminconfig/default_policies.rego
@@ -22,3 +22,39 @@ config[{"capability": "copy", "decision": decision}] {
     policy := {"ID": "copy-request", "description":"Copy (ingest) capability is requested by the user", "version": "0.1"}
     decision := {"policy": policy, "deploy": "True"}
 }
+
+# delete capability deployment
+config[{"capability": "delete", "decision": decision}] {
+    input.request.usage == "delete"
+    policy := {"ID": "delete-request", "description":"Delete capability is requested by the user", "version": "0.1"}
+    decision := {"policy": policy, "deploy": "True"}
+}
+
+# do not deploy copy in scenarios different than read or copy
+config[{"capability": "copy", "decision": decision}] {
+    input.request.usage != "read"
+    input.request.usage != "copy"
+    policy := {"ID": "copy-disabled", "description":"Copy capability is not requested", "version": "0.1"}
+    decision := {"policy": policy, "deploy": "False"}
+}
+
+# do not deploy read in other scenarios
+config[{"capability": "read", "decision": decision}] {
+    input.request.usage != "read"
+    policy := {"ID": "read-disabled", "description":"Read capability is not requested", "version": "0.1"}
+    decision := {"policy": policy, "deploy": "False"}
+}
+
+# do not deploy write in other scenarios
+config[{"capability": "write", "decision": decision}] {
+    input.request.usage != "write"
+    policy := {"ID": "write-disabled", "description":"Write capability is not requested", "version": "0.1"}
+    decision := {"policy": policy, "deploy": "False"}
+}
+
+# do not deploy delete in other scenarios
+config[{"capability": "delete", "decision": decision}] {
+    input.request.usage != "delete"
+    policy := {"ID": "delete-disabled", "description":"Delete capability is not requested", "version": "0.1"}
+    decision := {"policy": policy, "deploy": "False"}
+}

--- a/site/docs/concepts/config-policies.md
+++ b/site/docs/concepts/config-policies.md
@@ -72,7 +72,8 @@ In a similar way, all policies are relevant for a FybrikApplication that does no
 
 ### Out of the box policies
 
-Out of the box policies come with the fybrik deployment. They define the deployment of basic capabilities, such as read and write. 
+Out of the box policies come with the fybrik deployment. They define the deployment of basic capabilities, such as read, write, copy and delete. 
+
 ```
 package adminconfig
 
@@ -88,6 +89,49 @@ config[{"capability": "write", "decision": decision}] {
     input.request.usage == "write"
     policy := {"ID": "write-default-enabled", "description":"Write capability is requested for workloads that write data", "version": "0.1"}
     decision := {"policy": policy, "deploy": "True"}
+}
+
+# copy requested by the user
+config[{"capability": "copy", "decision": decision}] {
+    input.request.usage == "copy"
+    policy := {"ID": "copy-request", "description":"Copy (ingest) capability is requested by the user", "version": "0.1"}
+    decision := {"policy": policy, "deploy": "True"}
+}
+
+# delete capability deployment
+config[{"capability": "delete", "decision": decision}] {
+    input.request.usage == "delete"
+    policy := {"ID": "delete-request", "description":"Delete capability is requested by the user", "version": "0.1"}
+    decision := {"policy": policy, "deploy": "True"}
+}
+
+# do not deploy copy in scenarios different from read or copy
+config[{"capability": "copy", "decision": decision}] {
+    input.request.usage != "read"
+    input.request.usage != "copy"
+    policy := {"ID": "copy-disabled", "description":"Copy capability is not requested", "version": "0.1"}
+    decision := {"policy": policy, "deploy": "False"}
+}
+
+# do not deploy read in other scenarios
+config[{"capability": "read", "decision": decision}] {
+    input.request.usage != "read"
+    policy := {"ID": "read-disabled", "description":"Read capability is not requested", "version": "0.1"}
+    decision := {"policy": policy, "deploy": "False"}
+}
+
+# do not deploy write in other scenarios
+config[{"capability": "write", "decision": decision}] {
+    input.request.usage != "write"
+    policy := {"ID": "write-disabled", "description":"Write capability is not requested", "version": "0.1"}
+    decision := {"policy": policy, "deploy": "False"}
+}
+
+# do not deploy delete in other scenarios
+config[{"capability": "delete", "decision": decision}] {
+    input.request.usage != "delete"
+    policy := {"ID": "delete-disabled", "description":"Delete capability is not requested", "version": "0.1"}
+    decision := {"policy": policy, "deploy": "False"}
 }
 
 ```


### PR DESCRIPTION
Fixes https://github.com/fybrik/fybrik/issues/1377

This PR does not allow to deploy read/write modules when read/write is not requested. Copy is not deployed in scenarios that are neither read nor copy. 
Also adds policies for delete modules deployment.