### PR TITLE
Add missing return statement

### DIFF
--- a/connectors/katalog/pkg/connector/connector.go
+++ b/connectors/katalog/pkg/connector/connector.go
@@ -51,6 +51,7 @@ func (r *Handler) getAssetInfo(c *gin.Context) {
 	if len(splittedID) != 2 {
 		errorMessage := fmt.Sprintf("request has an invalid asset ID %s (must be in namespace/name format)", request.AssetID)
 		c.JSON(http.StatusBadRequest, gin.H{"error": errorMessage})
+		return
 	}
 	namespace, name := splittedID[0], splittedID[1]
 


### PR DESCRIPTION
This PR fixes a bug in getAssetInfo katalog-connector implementation.

Signed-off-by: Rohith D Vallam <rovallam@in.ibm.com>