### PR TITLE
Fix template name

### DIFF
--- a/manager/controllers/app/fybrikapplication_controller_unit_test.go
+++ b/manager/controllers/app/fybrikapplication_controller_unit_test.go
@@ -584,8 +584,6 @@ func TestMultipleDatasets(t *testing.T) {
 	g.Expect(plotter.Spec.Flows[1].AssetID).To(gomega.Equal("db2/redact-dataset"))
 	g.Expect(plotter.Spec.Flows[0].SubFlows).To(gomega.HaveLen(1))
 	g.Expect(plotter.Spec.Flows[1].SubFlows).To(gomega.HaveLen(2))
-	g.Expect(plotter.Spec.Templates).To(gomega.HaveKey("copy"))
-	g.Expect(plotter.Spec.Templates).To(gomega.HaveKey("read"))
 }
 
 // This test checks that a non-supported data store does not prevent a plotter from being created
@@ -1593,4 +1591,77 @@ func TestWriteWithoutPermissions(t *testing.T) {
 	g.Expect(cond.Status).To(gomega.BeIdenticalTo(corev1.ConditionTrue), "Deny condition is not set")
 	g.Expect(cond.Message).To(gomega.ContainSubstring(app.WriteNotAllowed))
 	g.Expect(application.Status.Ready).To(gomega.BeTrue())
+}
+
+func TestReadChain(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewGomegaWithT(t)
+	// Set the logger to development mode for verbose logs.
+	logf.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	namespaced := types.NamespacedName{
+		Name:      "read-test",
+		Namespace: "default",
+	}
+	application := &app.FybrikApplication{}
+	g.Expect(readObjectFromFile("../../testdata/unittests/data-usage.yaml", application)).NotTo(gomega.HaveOccurred())
+	application.Spec.Data[0] = app.DataContext{
+		DataSetID:    "s3/redact-dataset",
+		Requirements: app.DataRequirements{Interface: taxonomy.Interface{Protocol: app.ArrowFlight}},
+	}
+	application.SetGeneration(1)
+	application.SetUID("21")
+	// Objects to track in the fake client.
+	objs := []runtime.Object{
+		application,
+	}
+
+	// Register operator types with the runtime scheme.
+	s := utils.NewScheme(g)
+
+	// Create a fake client to mock API calls.
+	cl := fake.NewFakeClientWithScheme(s, objs...)
+
+	// Read module
+	readModule := &app.FybrikModule{}
+	g.Expect(readObjectFromFile("../../testdata/unittests/module-read-parquet.yaml", readModule)).NotTo(gomega.HaveOccurred())
+	readModule.Namespace = utils.GetControllerNamespace()
+	g.Expect(cl.Create(context.TODO(), readModule)).NotTo(gomega.HaveOccurred(), "the read module could not be created")
+	transformModule := &app.FybrikModule{}
+	g.Expect(readObjectFromFile("../../testdata/unittests/module-transform.yaml", transformModule)).NotTo(gomega.HaveOccurred())
+	transformModule.Namespace = utils.GetControllerNamespace()
+	transformModule.Spec.Capabilities[0].Capability = "read"
+	transformModule.Spec.Capabilities[0].Scope = "workload"
+	g.Expect(cl.Create(context.TODO(), transformModule)).NotTo(gomega.HaveOccurred(), "the transform module could not be created")
+
+	// Create a FybrikApplicationReconciler object with the scheme and fake client.
+	r := createTestFybrikApplicationController(cl, s)
+	g.Expect(r).NotTo(gomega.BeNil())
+
+	req := reconcile.Request{
+		NamespacedName: namespaced,
+	}
+
+	_, err := r.Reconcile(context.Background(), req)
+	g.Expect(err).To(gomega.BeNil())
+
+	err = cl.Get(context.TODO(), req.NamespacedName, application)
+	g.Expect(err).To(gomega.BeNil(), "Cannot fetch fybrikapplication")
+	g.Expect(getErrorMessages(application)).To(gomega.BeEmpty())
+	// check plotter creation
+	g.Expect(application.Status.Generated).ToNot(gomega.BeNil())
+	endpoint := application.Status.AssetStates[application.Spec.Data[0].DataSetID].Endpoint
+	g.Expect(endpoint).To(gomega.Not(gomega.BeNil()))
+	connectionMap := endpoint.AdditionalProperties.Items
+	g.Expect(connectionMap).To(gomega.HaveKey("fybrik-arrow-flight"))
+	config := connectionMap["fybrik-arrow-flight"].(map[string]interface{})
+	g.Expect(config["hostname"]).To(gomega.Equal("arrow-flight-transform"))
+	plotterObjectKey := types.NamespacedName{
+		Namespace: application.Status.Generated.Namespace,
+		Name:      application.Status.Generated.Name,
+	}
+	plotter := &app.Plotter{}
+	err = cl.Get(context.Background(), plotterObjectKey, plotter)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(plotter.Spec.Templates).To(gomega.HaveLen(2)) // expect two templates
 }

--- a/manager/controllers/app/plotter_generator.go
+++ b/manager/controllers/app/plotter_generator.go
@@ -141,10 +141,10 @@ func getDatasetCredentials(item *DataInfo) map[string]app.Vault {
 	return vaultMap
 }
 
-func (p *PlotterGenerator) addTemplate(element *ResolvedEdge, plotterSpec *app.PlotterSpec) {
+func (p *PlotterGenerator) addTemplate(element *ResolvedEdge, plotterSpec *app.PlotterSpec, templateName string) {
 	moduleCapability := element.Module.Spec.Capabilities[element.CapabilityIndex]
 	template := app.Template{
-		Name: string(moduleCapability.Capability),
+		Name: templateName,
 		Modules: []app.ModuleInfo{{
 			Name:       element.Module.Name,
 			Type:       element.Module.Spec.Type,
@@ -157,7 +157,7 @@ func (p *PlotterGenerator) addTemplate(element *ResolvedEdge, plotterSpec *app.P
 }
 
 func (p *PlotterGenerator) addInMemoryStep(element *ResolvedEdge, datasetID string, api *datacatalog.ResourceDetails,
-	steps []app.DataFlowStep) []app.DataFlowStep {
+	steps []app.DataFlowStep, templateName string) []app.DataFlowStep {
 	if steps == nil {
 		steps = []app.DataFlowStep{}
 	}
@@ -171,7 +171,7 @@ func (p *PlotterGenerator) addInMemoryStep(element *ResolvedEdge, datasetID stri
 	}
 	steps = append(steps, app.DataFlowStep{
 		Cluster:  element.Cluster,
-		Template: string(element.Module.Spec.Capabilities[element.CapabilityIndex].Capability),
+		Template: templateName,
 		Parameters: &app.StepParameters{
 			Arguments: []*app.StepArgument{{
 				AssetID: assetID,
@@ -185,13 +185,13 @@ func (p *PlotterGenerator) addInMemoryStep(element *ResolvedEdge, datasetID stri
 }
 
 func (p *PlotterGenerator) addStep(element *ResolvedEdge, datasetID string, api *datacatalog.ResourceDetails,
-	steps []app.DataFlowStep) []app.DataFlowStep {
+	steps []app.DataFlowStep, templateName string) []app.DataFlowStep {
 	if steps == nil {
 		steps = []app.DataFlowStep{}
 	}
 	steps = append(steps, app.DataFlowStep{
 		Cluster:  element.Cluster,
-		Template: string(element.Module.Spec.Capabilities[element.CapabilityIndex].Capability),
+		Template: templateName,
 		Parameters: &app.StepParameters{
 			Arguments: []*app.StepArgument{{AssetID: datasetID}, {AssetID: datasetID + "-copy"}},
 			API:       api,
@@ -220,8 +220,10 @@ func (p *PlotterGenerator) AddFlowInfoForAsset(item *DataInfo, application *app.
 	}
 	for _, element := range selection.DataPath {
 		moduleCapability := element.Module.Spec.Capabilities[element.CapabilityIndex]
-		p.Log.Trace().Str(logging.DATASETID, item.Context.DataSetID).Msgf("Adding module for %s", moduleCapability.Capability)
-		p.addTemplate(element, plotterSpec)
+		p.Log.Trace().Str(logging.DATASETID, item.Context.DataSetID).Msgf("Adding module %s for capability %s", element.Module.Name,
+			moduleCapability.Capability)
+		templateName := element.Module.Name + "-" + string(moduleCapability.Capability)
+		p.addTemplate(element, plotterSpec, templateName)
 		var api *datacatalog.ResourceDetails
 		if moduleCapability.API != nil {
 			if api, err = moduleAPIToService(moduleCapability.API, moduleCapability.Scope,
@@ -236,7 +238,7 @@ func (p *PlotterGenerator) AddFlowInfoForAsset(item *DataInfo, application *app.
 				p.Log.Error().Err(err).Str(logging.DATASETID, item.Context.DataSetID).Msg("Storage allocation for copy failed")
 				return err
 			}
-			steps = p.addStep(element, datasetID, api, steps)
+			steps = p.addStep(element, datasetID, api, steps, templateName)
 			copyAssetID := steps[len(steps)-1].Parameters.Arguments[1].AssetID
 			copyAsset := app.AssetDetails{
 				AdvertisedAssetID: datasetID,
@@ -252,7 +254,7 @@ func (p *PlotterGenerator) AddFlowInfoForAsset(item *DataInfo, application *app.
 			// clear steps
 			steps = nil
 		} else {
-			steps = p.addInMemoryStep(element, datasetID, api, steps)
+			steps = p.addInMemoryStep(element, datasetID, api, steps, templateName)
 		}
 	}
 	if steps != nil {

--- a/manager/controllers/app/select_modules.go
+++ b/manager/controllers/app/select_modules.go
@@ -385,14 +385,13 @@ func (p *PathBuilder) allowCapability(capability taxonomy.Capability) bool {
 func (p *PathBuilder) validateModuleRestrictions(edge *Edge) bool {
 	capability := edge.Module.Spec.Capabilities[edge.CapabilityIndex]
 	moduleSpec := edge.Module.Spec
-	restrictions := p.Asset.Configuration.ConfigDecisions[capability.Capability].DeploymentRestrictions.Modules
+	restrictions := []adminconfig.Restriction{}
 	oldPrefix := "capabilities."
 	newPrefix := oldPrefix + strconv.Itoa(edge.CapabilityIndex) + "."
-	for i := range restrictions {
-		if strings.Contains(restrictions[i].Property, oldPrefix) && !strings.Contains(restrictions[i].Property, newPrefix) {
-			restrictions[i].Property = strings.Replace(restrictions[i].Property, oldPrefix,
-				newPrefix, 1)
-		}
+	for i := range p.Asset.Configuration.ConfigDecisions[capability.Capability].DeploymentRestrictions.Modules {
+		restrict := p.Asset.Configuration.ConfigDecisions[capability.Capability].DeploymentRestrictions.Modules[i]
+		restrict.Property = strings.Replace(restrict.Property, oldPrefix, newPrefix, 1)
+		restrictions = append(restrictions, restrict)
 	}
 	return p.validateRestrictions(restrictions, &moduleSpec, "")
 }


### PR DESCRIPTION
Signed-off-by: Shlomit Koyfman <shlomitk@il.ibm.com>
Fixes https://github.com/fybrik/fybrik/issues/1387
- Template name is set to module name + capability instead of capability
- Added a test to check two read modules chained
- Fixed a bug in validating module restriction (the original item was changed instead of its copy)