### PR TITLE
upgrade vault and vault api to fix security issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/go-chi/chi v4.1.2+incompatible
 	github.com/go-chi/render v1.0.1
 	github.com/hashicorp/go-retryablehttp v0.7.0
-	github.com/hashicorp/vault/api v1.3.0
+	github.com/hashicorp/vault/api v1.3.1
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/mpvl/unique v0.0.0-20150818121801-cbe035fff7de
 	github.com/onsi/ginkgo v1.16.5

--- a/go.sum
+++ b/go.sum
@@ -754,8 +754,8 @@ github.com/hashicorp/memberlist v0.3.0/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOn
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hashicorp/serf v0.9.5/go.mod h1:UWDWwZeL5cuWDJdl0C6wrvrUwEqtQ4ZKBKKENpqIUyk=
 github.com/hashicorp/serf v0.9.6/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpTwn9UV4=
-github.com/hashicorp/vault/api v1.3.0 h1:uDy39PLSvy6gtKyjOCRPizy2QdFiIYSWBR2pxCEzYL8=
-github.com/hashicorp/vault/api v1.3.0/go.mod h1:EabNQLI0VWbWoGlA+oBLC8PXmR9D60aUVgQGvangFWQ=
+github.com/hashicorp/vault/api v1.3.1 h1:pkDkcgTh47PRjY1NEFeofqR4W/HkNUi9qIakESO2aRM=
+github.com/hashicorp/vault/api v1.3.1/go.mod h1:QeJoWxMFt+MsuWcYhmwRLwKEXrjwAFFywzhptMsTIUw=
 github.com/hashicorp/vault/sdk v0.3.0 h1:kR3dpxNkhh/wr6ycaJYqp6AFT/i2xaftbfnwZduTKEY=
 github.com/hashicorp/vault/sdk v0.3.0/go.mod h1:aZ3fNuL5VNydQk8GcLJ2TV8YCRVvyaakYkhZRoVuhj0=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=

--- a/hack/tools/install_vault.sh
+++ b/hack/tools/install_vault.sh
@@ -6,7 +6,7 @@
 cd "${0%/*}"
 source ./common.sh
 
-version=1.4.3
+version=1.8.9
 
 header_text "Checking for bin/vault"
 [[ -f bin/vault ]] && exit 0

--- a/hack/tools/install_vault.sh
+++ b/hack/tools/install_vault.sh
@@ -6,15 +6,15 @@
 cd "${0%/*}"
 source ./common.sh
 
-version=1.8.9
+DESIRED_VERSION=1.8.9
 
-header_text "Checking for bin/vault"
-[[ -f bin/vault ]] && exit 0
+header_text "Checking for bin/vault $DESIRED_VERSION"
+[[ -f bin/vault &&  `bin/vault -v | awk '{print $2}'` == "v$DESIRED_VERSION" ]] && exit 0
 
-header_text "Installing bin/vault"
+header_text "Installing bin/vault $DESIRED_VERSION"
 mkdir -p ./bin
-curl -L -o ./bin/vault.zip https://releases.hashicorp.com/vault/${version}/vault_${version}_${os}_amd64.zip 
-unzip ./bin/vault.zip -d ./bin/
+curl -L -o ./bin/vault.zip https://releases.hashicorp.com/vault/${DESIRED_VERSION}/vault_${DESIRED_VERSION}_${os}_amd64.zip
+unzip -o ./bin/vault.zip -d ./bin/
 rm ./bin/vault.zip
 
 chmod +x ./bin/vault


### PR DESCRIPTION
In this PR:
1. upgrade vault api from `1.3.0` to `1.3.1`
2. upgrade vault local binary from `1.4.3` to `1.8.9`
3. keeps the vault helm chart version `1.9.2` (latest version) untouched

From the CVE link:
https://www.whitesourcesoftware.com/vulnerability-database/CVE-2022-25243