### PR TITLE
upgrade base image to ubi-minimal:8.5

### DIFF
--- a/connectors/katalog/Dockerfile
+++ b/connectors/katalog/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
 
 ENV HOME=/tmp
 WORKDIR /tmp

--- a/connectors/opa/Dockerfile
+++ b/connectors/opa/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
 
 ENV HOME=/tmp
 WORKDIR /tmp

--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2020 IBM Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
 ENV HOME=/tmp
 WORKDIR /tmp
 COPY manager /

--- a/samples/rest-server/Dockerfile
+++ b/samples/rest-server/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2020 IBM Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
 ENV HOME=/tmp
 WORKDIR /tmp
 

--- a/test/services/datacatalog/Dockerfile
+++ b/test/services/datacatalog/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
 ENV HOME=/tmp
 WORKDIR /tmp
 

--- a/test/services/policymanager/Dockerfile
+++ b/test/services/policymanager/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
 
 ENV HOME=/tmp
 WORKDIR /tmp


### PR DESCRIPTION
Signed-off-by: Yi Yang Huang <hyiyang@cn.ibm.com>

This PR tries to fix security vulnerabilities (reported by Aqua) on the following 4 image, all 4 images shares the same CVE lists (from bash, gencat and openssl) and we think it comes from the base image `registry.access.redhat.com/ubi8/ubi-minimal`:
- katalog-connector
- manager
- opa-connector
- serverpolicymanager-mock
  
Also, from Redhat doc https://catalog.redhat.com/software/containers/ubi8-minimal/5c64772edd19c77a158ea216?push_date=1648459447000&architecture=amd64, `ubi-minimal:8.5` is the only ubi-minimal image that `does not have any unapplied Critical or Important security updates`
  
CVE list:
 CVE-2017-5932
CVE-2019-18276
 CVE-2019-9169
CVE-2022-23219
CVE-2022-23218
CVE-2021-35942
 CVE-2020-6096
 CVE-2019-6488
CVE-2021-38604
 CVE-2021-3326
 CVE-2019-9192
CVE-2018-20796
CVE-2018-19591
 CVE-2020-1751
 CVE-2020-1752
CVE-2019-25013
CVE-2020-10029
CVE-2020-27618
 CVE-2019-7309
CVE-2016-10739
CVE-2019-19126
 CVE-2021-3711
 CVE-2022-0778
 CVE-2021-3712
 CVE-2021-4160