### PR TITLE
Prevent Build action faild for unrelease pushes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,7 +197,7 @@ jobs:
       DOCKER_USERNAME: ${{ github.actor }}
       DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
     needs: [verify, test, integration-tests]
-    if: ${{ github.event_name != 'pull_request' && github.repository == 'fybrik/fybrik'  }}
+    if: ${{ github.event_name != 'pull_request' && github.repository == 'fybrik/fybrik' && startsWith(github.ref, 'refs/tags/v') }}
     steps:
     - uses: actions/checkout@v2
     - name: Download artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,7 +184,7 @@ jobs:
         dockerhub_hostname: docker.io
         git_user: fake@fake.com
         image_repo: kind-registry:5000
-        image_source_repo_username: fake@fake.com 
+        image_source_repo_username: fake@fake.com
         GH_TOKEN: fake
       run: pushd hack/tools/ && ./create_kind.sh && docker info && popd && . pipeline/source-external.sh && skip_tests=false kind=true github_workspace=${{ github.workspace }} pipeline/bootstrap-pipeline.sh fybrik-system
 
@@ -197,7 +197,7 @@ jobs:
       DOCKER_USERNAME: ${{ github.actor }}
       DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
     needs: [verify, test, integration-tests]
-    if: ${{ github.event_name != 'pull_request' && github.repository == 'fybrik/fybrik' && startsWith(github.ref, 'refs/tags/v' }}
+    if: ${{ github.event_name != 'pull_request' && github.repository == 'fybrik/fybrik'  }}
     steps:
     - uses: actions/checkout@v2
     - name: Download artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,6 @@ on:
   pull_request:
     branches:
       - master
-      - 'releases/**'
 
 env:
   GO_VERSION: 1.17

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - master
+      - 'releases/**'
 
 env:
   GO_VERSION: 1.17
@@ -201,7 +202,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Download artifact
-      if: ${{ github.event_name != 'pull_request' }}
       uses: actions/download-artifact@v2
       with:
         name: images
@@ -237,7 +237,6 @@ jobs:
         echo ::set-output name=version::$version
         echo ::set-output name=push_tag_event::$push_tag_event
     - name: Publish images
-      if: ${{ github.event_name != 'pull_request' }}
       env:
         DOCKER_PUBLIC_TAGNAME:  ${{ steps.version.outputs.version }}
       run: make docker-retag-and-push-public && make helm-push-public

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,7 +197,7 @@ jobs:
       DOCKER_USERNAME: ${{ github.actor }}
       DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
     needs: [verify, test, integration-tests]
-    if: ${{ github.event_name != 'pull_request' && github.repository == 'fybrik/fybrik' }}
+    if: ${{ github.event_name != 'pull_request' && github.repository == 'fybrik/fybrik' && startsWith(github.ref, 'refs/tags/v' }}
     steps:
     - uses: actions/checkout@v2
     - name: Download artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - master
+      - 'releases/**'
 
 env:
   GO_VERSION: 1.17

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,7 +198,7 @@ jobs:
       DOCKER_USERNAME: ${{ github.actor }}
       DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
     needs: [verify, test, integration-tests]
-    if: ${{ github.event_name != 'pull_request' && github.repository == 'fybrik/fybrik' && startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ github.event_name != 'pull_request' && github.repository == 'fybrik/fybrik' && "GITHUB_REF##*/" == 'master' }}
     steps:
     - uses: actions/checkout@v2
     - name: Download artifact


### PR DESCRIPTION
Some push requests, e.g. cherry-peak and release branch creation fails when they cannot push images.

This PR prevents the push-images step for none release events.

Signed-off-by: Alexey Roytman [roytman@il.ibm.com](mailto:roytman@il.ibm.com)