### PR TITLE
Fix python-publish workflow.

### DIFF
--- a/.github/workflows/python-publish.yaml
+++ b/.github/workflows/python-publish.yaml
@@ -29,7 +29,7 @@ jobs:
         pip install build
     - name: Build logging package
       run: |
-        if echo ${{ github.event.inputs.logging-version }} | grep -c "do-not-publish"
+        if [ ${{ github.event.inputs.logging-version }} == "do-not-publish" ]
         then
           echo "do not publish logging library"
         else
@@ -37,7 +37,7 @@ jobs:
         fi
     - name: Build vault package
       run: |
-        if echo ${{ github.event.inputs.vault-version }} | grep -c "do-not-publish"
+        if [ ${{ github.event.inputs.vault-version }} == "do-not-publish" ]
         then
           echo "do not publish vault library"
         else

--- a/.github/workflows/python-publish.yaml
+++ b/.github/workflows/python-publish.yaml
@@ -33,7 +33,6 @@ jobs:
         then
           echo "do not publish logging library"
         else
-          echo "else logging"
           VERSION=${{ github.event.inputs.logging-version }} python -m build ./python/logging --outdir ./dist
         fi
     - name: Build vault package
@@ -42,7 +41,6 @@ jobs:
         then
           echo "do not publish vault library"
         else
-          echo "else vault"
           VERSION=${{ github.event.inputs.vault-version }} python -m build ./python/vault --outdir ./dist
         fi
     - name: Publish package

--- a/.github/workflows/python-publish.yaml
+++ b/.github/workflows/python-publish.yaml
@@ -2,9 +2,12 @@ name: python-publish
 on:
   workflow_dispatch:
     inputs:
-      library-version:
+      logging-version:
         required: true
-        default: '0.1.0'
+        default: 'do-not-publish'
+      vault-version:
+        required: true
+        default: 'do-not-publish'
       pypi-repository-url:
         required: true
         default: 'https://upload.pypi.org/legacy/'
@@ -25,9 +28,23 @@ jobs:
         python -m pip install --upgrade pip
         pip install build
     - name: Build logging package
-      run: VERSION=${{ github.event.inputs.library-version }} python -m build ./python/logging --outdir ./dist
+      run: |
+        if echo ${{ github.event.inputs.logging-version }} | grep -c "do-not-publish"
+        then
+          echo "do not publish logging library"
+        else
+          echo "else logging"
+          VERSION=${{ github.event.inputs.logging-version }} python -m build ./python/logging --outdir ./dist
+        fi
     - name: Build vault package
-      run: VERSION=${{ github.event.inputs.library-version }} python -m build ./python/vault --outdir ./dist
+      run: |
+        if echo ${{ github.event.inputs.vault-version }} | grep -c "do-not-publish"
+        then
+          echo "do not publish vault library"
+        else
+          echo "else vault"
+          VERSION=${{ github.event.inputs.vault-version }} python -m build ./python/vault --outdir ./dist
+        fi
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@release/v1
       with:


### PR DESCRIPTION
Add an option of 'do-not-publish' flag to not publish a library that was already published.

Signed-off-by: mohammad-nassar10 <mohammad.nassar@ibm.com>