### PR TITLE
Set deny status condition when no storage is available for writing new data

### DIFF
--- a/manager/controllers/app/fybrikapplication_controller.go
+++ b/manager/controllers/app/fybrikapplication_controller.go
@@ -611,6 +611,13 @@ func (r *FybrikApplicationReconciler) checkGovernanceActions(configEvaluatorInpu
 			return err
 		}
 	}
+	// write is denied to all accounts, return Deny for write and copy flows
+	if len(req.StorageRequirements) == 0 {
+		if (req.Context.Requirements.FlowParams.IsNewDataSet && configEvaluatorInput.Request.Usage == taxonomy.WriteFlow) ||
+			(configEvaluatorInput.Request.Usage == taxonomy.CopyFlow) {
+			return errors.New(api.WriteNotAllowed)
+		}
+	}
 	return nil
 }
 

--- a/manager/controllers/app/fybrikapplication_controller_unit_test.go
+++ b/manager/controllers/app/fybrikapplication_controller_unit_test.go
@@ -965,8 +965,11 @@ func TestCopyDataNotAllowed(t *testing.T) {
 	g.Expect(err).To(gomega.BeNil(), "Cannot fetch fybrikapplication")
 	// check provisioned storage
 	g.Expect(application.Status.ProvisionedStorage).To(gomega.BeEmpty())
-	// check errors
-	g.Expect(getErrorMessages(application)).NotTo(gomega.BeEmpty())
+	// Expect Deny condition
+	cond := application.Status.AssetStates[assetName].Conditions[DenyConditionIndex]
+	g.Expect(cond.Status).To(gomega.BeIdenticalTo(corev1.ConditionTrue), "Deny condition is not set")
+	g.Expect(cond.Message).To(gomega.ContainSubstring(v1alpha1.WriteNotAllowed))
+	g.Expect(application.Status.Ready).To(gomega.BeTrue())
 }
 
 // This test checks the ingest scenario


### PR DESCRIPTION
Signed-off-by: Shlomit Koyfman <shlomitk@il.ibm.com>
Fixes https://github.com/fybrik/fybrik/issues/1493

When no storage is available for writing, and an explicit copy is required (copy or write a new asset), Deny is reported in the status.