### PR TITLE
Remove redundant code form helmer

### DIFF
--- a/charts/fybrik/templates/manager-deployment.yaml
+++ b/charts/fybrik/templates/manager-deployment.yaml
@@ -119,6 +119,10 @@ spec:
             {{- if .Values.manager.extraEnvs }}
             {{- toYaml .Values.manager.extraEnvs | nindent 12 }}
             {{- end }}
+            {{- if .Values.manager.chartVolume }}
+            - name: CHECK_LOCAL_CHARTS
+              value: "true"
+            {{- end }}
           {{- if .Values.clusterScoped }} 
           ports:
             - containerPort: 9443

--- a/manager/controllers/app/blueprint_controller.go
+++ b/manager/controllers/app/blueprint_controller.go
@@ -17,6 +17,7 @@ import (
 	credentialprovider "github.com/vdemeester/k8s-pkg-credentialprovider"
 	credentialprovidersecrets "github.com/vdemeester/k8s-pkg-credentialprovider/secrets"
 	"gopkg.in/yaml.v2"
+	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/release"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -64,9 +65,13 @@ func (r *BlueprintReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	log := r.Log.With().Str(utils.FybrikAppUUID, uuid).
 		Str("blueprint", req.NamespacedName.String()).Logger()
 
-	if res, err := r.reconcileFinalizers(ctx, &blueprint); err != nil {
+	cfg, err := r.Helmer.GetConfig(blueprint.Spec.ModulesNamespace, log.Printf)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if res, errF := r.reconcileFinalizers(ctx, cfg, &blueprint); errF != nil {
 		log.Error().Err(err).Msg("Could not reconcile blueprint " + blueprint.GetName() + " finalizers")
-		return res, err
+		return res, errF
 	}
 
 	// If the object has a scheduled deletion time, update status and return
@@ -79,7 +84,7 @@ func (r *BlueprintReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	observedStatus := blueprint.Status.DeepCopy()
 	log.Trace().Str(logging.ACTION, logging.CREATE).Msg("Installing/Updating blueprint " + blueprint.GetName())
 
-	result, err := r.reconcile(ctx, &log, &blueprint)
+	result, err := r.reconcile(ctx, cfg, &log, &blueprint)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "failed to reconcile blueprint")
 	}
@@ -95,7 +100,8 @@ func (r *BlueprintReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 }
 
 // reconcileFinalizers reconciles finalizers for Blueprint
-func (r *BlueprintReconciler) reconcileFinalizers(ctx context.Context, blueprint *fapp.Blueprint) (ctrl.Result, error) {
+func (r *BlueprintReconciler) reconcileFinalizers(ctx context.Context, cfg *action.Configuration,
+	blueprint *fapp.Blueprint) (ctrl.Result, error) {
 	// finalizer
 	hasFinalizer := ctrlutil.ContainsFinalizer(blueprint, BlueprintFinalizerName)
 
@@ -104,7 +110,7 @@ func (r *BlueprintReconciler) reconcileFinalizers(ctx context.Context, blueprint
 		// The object is being deleted
 		if hasFinalizer { // Finalizer was created when the object was created
 			// the finalizer is present - delete the allocated resources
-			if err := r.deleteExternalResources(blueprint); err != nil {
+			if err := r.deleteExternalResources(cfg, blueprint); err != nil {
 				r.Log.Error().Err(err).Msg("Error while deleting owned resources")
 			}
 			// remove the finalizer from the list and update it, because it needs to be deleted together with the object
@@ -126,10 +132,10 @@ func (r *BlueprintReconciler) reconcileFinalizers(ctx context.Context, blueprint
 	return ctrl.Result{}, nil
 }
 
-func (r *BlueprintReconciler) deleteExternalResources(blueprint *fapp.Blueprint) error {
+func (r *BlueprintReconciler) deleteExternalResources(cfg *action.Configuration, blueprint *fapp.Blueprint) error {
 	errs := make([]string, 0)
 	for release := range blueprint.Status.Releases {
-		if _, err := r.Helmer.Uninstall(blueprint.Spec.ModulesNamespace, release); err != nil {
+		if _, err := r.Helmer.Uninstall(cfg, release); err != nil {
 			errs = append(errs, err.Error())
 		}
 	}
@@ -193,10 +199,9 @@ func (r *BlueprintReconciler) obtainSecrets(ctx context.Context, log *zerolog.Lo
 	return registrySuccessfulLogin, nil
 }
 
-func (r *BlueprintReconciler) applyChartResource(ctx context.Context, log *zerolog.Logger, chartSpec fapp.ChartSpec,
-	args map[string]interface{}, blueprint *fapp.Blueprint, releaseName string) (ctrl.Result, error) {
+func (r *BlueprintReconciler) applyChartResource(ctx context.Context, cfg *action.Configuration, chartSpec fapp.ChartSpec,
+	args map[string]interface{}, releaseNameSpace, releaseName string, log *zerolog.Logger) (ctrl.Result, error) {
 	log.Trace().Str(logging.ACTION, logging.CREATE).Msg("--- Chart Ref ---\n\n" + chartSpec.Name + "\n\n")
-	kubeNamespace := blueprint.Spec.ModulesNamespace
 
 	args = CopyMap(args)
 	for k, v := range chartSpec.Values {
@@ -221,7 +226,8 @@ func (r *BlueprintReconciler) applyChartResource(ctx context.Context, log *zerol
 			log.Error().Msgf("Error while calling RemoveAll on directory %s created for pulling helm chart", tmpDir)
 		}
 	}(log)
-	err = r.Helmer.Pull(chartSpec.Name, tmpDir)
+
+	err = r.Helmer.Pull(cfg, chartSpec.Name, tmpDir)
 	if err != nil {
 		return ctrl.Result{}, errors.WithMessage(err, chartSpec.Name+": failed chart pull")
 	}
@@ -236,15 +242,18 @@ func (r *BlueprintReconciler) applyChartResource(ctx context.Context, log *zerol
 	if err != nil {
 		return ctrl.Result{}, errors.WithMessage(err, chartSpec.Name+": failed chart load")
 	}
-
-	rel, err := r.Helmer.Status(kubeNamespace, releaseName)
-	if err == nil && rel != nil {
-		rel, err = r.Helmer.Upgrade(chart, kubeNamespace, releaseName, args)
+	inst, err := r.Helmer.IsInstalled(cfg, releaseName)
+	log.Trace().Str(logging.ACTION, logging.CREATE).Msg(fmt.Sprintf("check if release %s installed, return %t and error: %v",
+		releaseName, inst, err))
+	// TODO should we return err if it is not nil?
+	var rel *release.Release
+	if inst && err == nil {
+		rel, err = r.Helmer.Upgrade(ctx, cfg, chart, releaseNameSpace, releaseName, args)
 		if err != nil {
 			return ctrl.Result{}, errors.WithMessage(err, chartSpec.Name+": failed upgrade")
 		}
 	} else {
-		rel, err = r.Helmer.Install(chart, kubeNamespace, releaseName, args)
+		rel, err = r.Helmer.Install(ctx, cfg, chart, releaseNameSpace, releaseName, args)
 		if err != nil {
 			return ctrl.Result{}, errors.WithMessage(err, chartSpec.Name+": failed install")
 		}
@@ -298,9 +307,9 @@ func (r *BlueprintReconciler) updateModuleState(blueprint *fapp.Blueprint, insta
 }
 
 //nolint:gocyclo
-func (r *BlueprintReconciler) reconcile(ctx context.Context, log *zerolog.Logger, blueprint *fapp.Blueprint) (ctrl.Result, error) {
+func (r *BlueprintReconciler) reconcile(ctx context.Context, cfg *action.Configuration, log *zerolog.Logger,
+	blueprint *fapp.Blueprint) (ctrl.Result, error) {
 	uuid := utils.GetFybrikApplicationUUIDfromAnnotations(blueprint.GetAnnotations())
-	modulesNamespace := blueprint.Spec.ModulesNamespace
 	// Gather all templates and process them into a list of resources to apply
 	// force-update if the blueprint spec is different
 	updateRequired := blueprint.Status.ObservedGeneration != blueprint.GetGeneration()
@@ -342,20 +351,23 @@ func (r *BlueprintReconciler) reconcile(ctx context.Context, log *zerolog.Logger
 			blueprint.Labels[fapp.ApplicationNamespaceLabel], instanceName)
 		log.Trace().Msg("Release name: " + releaseName)
 		numReleases++
+
 		// check the release status
-		rel, err := r.Helmer.Status(modulesNamespace, releaseName)
-		// unexisting release or a failed release - re-apply the chart
+		rel, err := r.Helmer.Status(cfg, releaseName)
+		log.Trace().Msg(fmt.Sprintf("Check it re-apply the chart: updateRequired=%t, err=%v, rel is nil=%t",
+			updateRequired, err != nil, rel == nil))
+		// nonexistent release or a failed release - re-apply the chart
 		if updateRequired || err != nil || rel == nil || rel.Info.Status == release.StatusFailed {
 			// Process templates with arguments
 			chart := module.Chart
-			if _, err := r.applyChartResource(ctx, log, chart, args, blueprint, releaseName); err != nil {
+			if _, err := r.applyChartResource(ctx, cfg, chart, args, blueprint.Spec.ModulesNamespace, releaseName, log); err != nil {
 				blueprint.Status.ObservedState.Error += errors.Wrap(err, "ChartDeploymentFailure: ").Error() + "\n"
 				r.updateModuleState(blueprint, instanceName, false, err.Error())
 			} else {
 				r.updateModuleState(blueprint, instanceName, false, "")
 			}
 		} else if rel.Info.Status == release.StatusDeployed {
-			status, errMsg := r.checkReleaseStatus(releaseName, modulesNamespace, uuid)
+			status, errMsg := r.checkReleaseStatus(cfg, rel.Manifest, uuid)
 			if status == corev1.ConditionFalse {
 				blueprint.Status.ObservedState.Error += "ResourceAllocationFailure: " + errMsg + "\n"
 				r.updateModuleState(blueprint, instanceName, false, errMsg)
@@ -369,7 +381,7 @@ func (r *BlueprintReconciler) reconcile(ctx context.Context, log *zerolog.Logger
 	// clean-up
 	for release, version := range blueprint.Status.Releases {
 		if version != blueprint.Status.ObservedGeneration {
-			_, err := r.Helmer.Uninstall(modulesNamespace, release)
+			_, err := r.Helmer.Uninstall(cfg, release)
 			if err != nil {
 				log.Error().Err(err).Str(logging.ACTION, logging.DELETE).Msg("Error uninstalling release " + release)
 			} else {
@@ -512,11 +524,11 @@ func (r *BlueprintReconciler) matchesCondition(res *unstructured.Unstructured, c
 	return true
 }
 
-func (r *BlueprintReconciler) checkReleaseStatus(releaseName, namespace, uuid string) (corev1.ConditionStatus, string) {
+func (r *BlueprintReconciler) checkReleaseStatus(cfg *action.Configuration, manifest, uuid string) (corev1.ConditionStatus, string) {
 	log := r.Log.With().Str(utils.FybrikAppUUID, uuid).Logger()
 
 	// get all resources for the given helm release in their current state
-	resources, err := r.Helmer.GetResources(namespace, releaseName)
+	resources, err := r.Helmer.GetResources(cfg, manifest)
 	if err != nil {
 		log.Error().Err(err).Msg("Error getting resources")
 		return corev1.ConditionUnknown, ""

--- a/manager/main.go
+++ b/manager/main.go
@@ -218,8 +218,12 @@ func run(namespace string, metricsAddr string, enableLeaderElection bool,
 
 	if enableBlueprintController {
 		// Initiate the Blueprint Controller
-		setupLog.Trace().Msg("creating Blueprint controller")
-		blueprintController := app.NewBlueprintReconciler(mgr, "Blueprint", new(helm.Impl))
+		checkLocalMounts := false
+		if os.Getenv("CHECK_LOCAL_CHARTS") == "true" {
+			checkLocalMounts = true
+		}
+		setupLog.Trace().Str("check local charts", strconv.FormatBool(checkLocalMounts)).Msg("creating Blueprint controller")
+		blueprintController := app.NewBlueprintReconciler(mgr, "Blueprint", helm.NewHelmerImpl(checkLocalMounts))
 		if err := blueprintController.SetupWithManager(mgr); err != nil {
 			setupLog.Error().Err(err).Str(logging.CONTROLLER, "Blueprint").Msg("unable to create controller " + blueprintController.Name)
 			return 1

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -60,7 +60,7 @@ var (
 	password      = os.Getenv("DOCKER_PASSWORD")
 	insecure, _   = strconv.ParseBool(os.Getenv("DOCKER_INSECURE"))
 	chartRef      = ChartRef(hostname, namespace, chartName, tagName)
-	impl          = new(Impl)
+	impl          = NewHelmerImpl(true)
 )
 
 func ChartRef(hostname, namespace, name, tagname string) string {


### PR DESCRIPTION
- Remove repetitive calls of `getConfig`
- Remove some redundant code
- Several addition helm related calls optimizations.  

Signed-off-by: Alexey Roytman <roytman@il.ibm.com>