### PR TITLE
issue #1574 - normalize attribute values to scale

### DIFF
--- a/pkg/infrastructure/attribute_manager.go
+++ b/pkg/infrastructure/attribute_manager.go
@@ -176,7 +176,7 @@ func (m *AttributeManager) GetAttrFromArguments(name, arg1, arg2 string) *taxono
 }
 
 // // returns the normalized-to-scale value of an infrastructure attribute based on the attribute and two arguments to match
-func (m *AttributeManager) GetNormalizedAttrValueFromArguments(name, arg1, arg2 string, scale *taxonomy.RangeType) (string, error) {
+func (m *AttributeManager) GetNormAttrValFromArgs(name, arg1, arg2 string, scale *taxonomy.RangeType) (string, error) {
 	element := m.GetAttrFromArguments(name, arg1, arg2)
 	if element == nil {
 		return "", fmt.Errorf("attribute %s is not defined for regions %s and %s", name, arg1, arg2)

--- a/pkg/optimizer/datapath_csp.go
+++ b/pkg/optimizer/datapath_csp.go
@@ -816,7 +816,7 @@ func (dpc *DataPathCSP) getCluster2ClusterParamArray(attr string) (string, error
 	c2cParamArray := []string{}
 	for _, cluster1 := range dpc.env.Clusters {
 		for _, cluster2 := range dpc.env.Clusters {
-			value, err := dpc.env.AttributeManager.GetNormalizedAttrValueFromArguments(attr, cluster1.Metadata.Region, cluster2.Metadata.Region, scale)
+			value, err := dpc.env.AttributeManager.GetNormAttrValFromArgs(attr, cluster1.Metadata.Region, cluster2.Metadata.Region, scale)
 			if err != nil {
 				return "", err
 			}
@@ -839,7 +839,7 @@ func (dpc *DataPathCSP) getStorageToClusterParamArray(attr string) (string, erro
 	s2cParamArray := []string{}
 	dataSetRegion := dpc.problemData.DataDetails.ResourceMetadata.Geography
 	for _, cluster := range dpc.env.Clusters {
-		value, err := dpc.env.AttributeManager.GetNormalizedAttrValueFromArguments(attr, dataSetRegion, cluster.Metadata.Region, scale)
+		value, err := dpc.env.AttributeManager.GetNormAttrValFromArgs(attr, dataSetRegion, cluster.Metadata.Region, scale)
 		if err != nil {
 			return "", err
 		}
@@ -847,7 +847,7 @@ func (dpc *DataPathCSP) getStorageToClusterParamArray(attr string) (string, erro
 	}
 	for _, sa := range dpc.env.StorageAccounts {
 		for _, cluster := range dpc.env.Clusters {
-			value, err := dpc.env.AttributeManager.GetNormalizedAttrValueFromArguments(attr, string(sa.Spec.Region), cluster.Metadata.Region, scale)
+			value, err := dpc.env.AttributeManager.GetNormAttrValFromArgs(attr, string(sa.Spec.Region), cluster.Metadata.Region, scale)
 			if err != nil {
 				return "", err
 			}

--- a/pkg/optimizer/datapath_csp.go
+++ b/pkg/optimizer/datapath_csp.go
@@ -660,18 +660,13 @@ func (dpc *DataPathCSP) setSimpleGoalVarArray(attr string, instanceType taxonomy
 // This creates a param array with the values of the given attribute for each cluster/module/storage account instance
 // NOTE: We currently assume all values are integers. Code should be changed if some values are floats.
 func (dpc *DataPathCSP) getAttributeMapping(attr string, instanceType taxonomy.InstanceType) (string, string, error) {
-	scale, err := dpc.env.AttributeManager.GetScale(attr)
-	if err != nil {
-		return "", "", err
-	}
-
 	resArray := []string{}
 	varName := ""
 	switch instanceType {
 	case taxonomy.Cluster:
 		varName = clusterVarname
 		for _, cluster := range dpc.env.Clusters {
-			infraElementValue, err := dpc.env.AttributeManager.GetNormalizedAttributeValue(attr, cluster.Name, scale)
+			infraElementValue, err := dpc.env.AttributeManager.GetNormalizedAttributeValue(attr, cluster.Name)
 			if err != nil {
 				return "", "", err
 			}
@@ -680,9 +675,9 @@ func (dpc *DataPathCSP) getAttributeMapping(attr string, instanceType taxonomy.I
 	case taxonomy.StorageAccount:
 		varName = saVarname
 		for _, sa := range dpc.env.StorageAccounts {
-			infraElementValue, err := dpc.env.AttributeManager.GetNormalizedAttributeValue(attr, sa.Name, scale)
+			infraElementValue, err := dpc.env.AttributeManager.GetNormalizedAttributeValue(attr, sa.Name)
 			if err != nil {
-				infraElementValue, err = dpc.env.AttributeManager.GetNormalizedAttributeValue(attr, sa.GenerateName, scale)
+				infraElementValue, err = dpc.env.AttributeManager.GetNormalizedAttributeValue(attr, sa.GenerateName)
 				if err != nil {
 					return "", "", err
 				}
@@ -693,7 +688,7 @@ func (dpc *DataPathCSP) getAttributeMapping(attr string, instanceType taxonomy.I
 	case taxonomy.Module:
 		varName = modCapVarname
 		for _, modCap := range dpc.modulesCapabilities {
-			infraElementValue, err := dpc.env.AttributeManager.GetNormalizedAttributeValue(attr, modCap.module.Name, scale)
+			infraElementValue, err := dpc.env.AttributeManager.GetNormalizedAttributeValue(attr, modCap.module.Name)
 			if err != nil {
 				return "", "", err
 			}
@@ -808,15 +803,10 @@ func (dpc *DataPathCSP) setComplexGoalsCommonVars(pathLen int) {
 
 // Produces a paramArray containing the attr value for each pair of clusters
 func (dpc *DataPathCSP) getCluster2ClusterParamArray(attr string) (string, error) {
-	scale, err := dpc.env.AttributeManager.GetScale(attr)
-	if err != nil {
-		return "", err
-	}
-
 	c2cParamArray := []string{}
 	for _, cluster1 := range dpc.env.Clusters {
 		for _, cluster2 := range dpc.env.Clusters {
-			value, err := dpc.env.AttributeManager.GetNormAttrValFromArgs(attr, cluster1.Metadata.Region, cluster2.Metadata.Region, scale)
+			value, err := dpc.env.AttributeManager.GetNormAttrValFromArgs(attr, cluster1.Metadata.Region, cluster2.Metadata.Region)
 			if err != nil {
 				return "", err
 			}
@@ -831,15 +821,10 @@ func (dpc *DataPathCSP) getCluster2ClusterParamArray(attr string) (string, error
 // Produces a paramArray containing the attr value for each pair of storage-account and cluster
 // The first line of the resulting matrix describes the attr value of the dataset-region vs each cluster
 func (dpc *DataPathCSP) getStorageToClusterParamArray(attr string) (string, error) {
-	scale, err := dpc.env.AttributeManager.GetScale(attr)
-	if err != nil {
-		return "", err
-	}
-
 	s2cParamArray := []string{}
 	dataSetRegion := dpc.problemData.DataDetails.ResourceMetadata.Geography
 	for _, cluster := range dpc.env.Clusters {
-		value, err := dpc.env.AttributeManager.GetNormAttrValFromArgs(attr, dataSetRegion, cluster.Metadata.Region, scale)
+		value, err := dpc.env.AttributeManager.GetNormAttrValFromArgs(attr, dataSetRegion, cluster.Metadata.Region)
 		if err != nil {
 			return "", err
 		}
@@ -847,7 +832,7 @@ func (dpc *DataPathCSP) getStorageToClusterParamArray(attr string) (string, erro
 	}
 	for _, sa := range dpc.env.StorageAccounts {
 		for _, cluster := range dpc.env.Clusters {
-			value, err := dpc.env.AttributeManager.GetNormAttrValFromArgs(attr, string(sa.Spec.Region), cluster.Metadata.Region, scale)
+			value, err := dpc.env.AttributeManager.GetNormAttrValFromArgs(attr, string(sa.Spec.Region), cluster.Metadata.Region)
 			if err != nil {
 				return "", err
 			}


### PR DESCRIPTION
Signed-off-by: Ziv Nevo <nevo@il.ibm.com>

Making sure that values are always between 0 (scale.Min) and 100 (scale.Max).
That is `(value - scale.Min) * 100 / (scale.Max - scale.Min)`