### PR TITLE
Remove extra reconciles of FybrikApplication

### DIFF
--- a/manager/controllers/app/blueprint_controller.go
+++ b/manager/controllers/app/blueprint_controller.go
@@ -116,7 +116,7 @@ func (r *BlueprintReconciler) reconcileFinalizers(ctx context.Context, cfg *acti
 			// remove the finalizer from the list and update it, because it needs to be deleted together with the object
 			ctrlutil.RemoveFinalizer(blueprint, BlueprintFinalizerName)
 
-			if err := utils.UpdateFinalizers(ctx, r.Client, blueprint); err != nil {
+			if err := r.Client.Update(ctx, blueprint); err != nil {
 				return ctrl.Result{}, err
 			}
 		}
@@ -125,7 +125,7 @@ func (r *BlueprintReconciler) reconcileFinalizers(ctx context.Context, cfg *acti
 	// Make sure this CRD instance has a finalizer
 	if !hasFinalizer {
 		ctrlutil.AddFinalizer(blueprint, BlueprintFinalizerName)
-		if err := utils.UpdateFinalizers(ctx, r.Client, blueprint); err != nil {
+		if err := r.Client.Update(ctx, blueprint); err != nil {
 			return ctrl.Result{}, err
 		}
 	}

--- a/manager/controllers/app/fybrikapplication_controller.go
+++ b/manager/controllers/app/fybrikapplication_controller.go
@@ -146,7 +146,7 @@ func (r *FybrikApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		}
 		r.checkReadiness(applicationContext, resourceStatus)
 	} else if (observedStatus.ObservedGeneration != appVersion) || !generationComplete {
-		if result, err := r.reconcile(applicationContext); err != nil {
+		if result, err := r.reconcile(applicationContext); err != nil || result.Requeue || (result.RequeueAfter > 0) {
 			// another attempt will be done
 			// users should be informed in case of errors
 			// ignore an update error, a new reconcile will be made in any case

--- a/manager/controllers/app/fybrikapplication_controller_unit_test.go
+++ b/manager/controllers/app/fybrikapplication_controller_unit_test.go
@@ -234,11 +234,11 @@ func TestFybrikApplicationFinalizers(t *testing.T) {
 	r := createTestFybrikApplicationController(cl, s)
 	g.Expect(r).NotTo(gomega.BeNil())
 	appContext := ApplicationContext{Application: application, Log: &r.Log}
-	g.Expect(r.reconcileFinalizers(context.TODO(), appContext)).To(gomega.BeNil())
+	g.Expect(r.addFinalizers(context.TODO(), appContext)).To(gomega.BeNil())
 	g.Expect(application.Finalizers).NotTo(gomega.BeEmpty(), "finalizers have not been created")
 	// mark application as deleted
 	application.DeletionTimestamp = &metav1.Time{Time: time.Now()}
-	g.Expect(r.reconcileFinalizers(context.TODO(), appContext)).To(gomega.BeNil())
+	g.Expect(r.removeFinalizers(context.TODO(), appContext)).To(gomega.BeNil())
 	g.Expect(application.Finalizers).To(gomega.BeEmpty(), "finalizers have not been removed")
 }
 

--- a/manager/controllers/app/fybrikapplication_controller_unit_test.go
+++ b/manager/controllers/app/fybrikapplication_controller_unit_test.go
@@ -1100,7 +1100,8 @@ func TestPlotterUpdate(t *testing.T) {
 	g.Expect(cl.Update(context.Background(), plotter)).NotTo(gomega.HaveOccurred())
 
 	// the new reconcile should update the application state
-	_, err = r.Reconcile(context.Background(), req)
+	newReq := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: req.Namespace, Name: "plotter_" + req.Name}}
+	_, err = r.Reconcile(context.Background(), newReq)
 	g.Expect(err).To(gomega.BeNil())
 	err = cl.Get(context.Background(), req.NamespacedName, application)
 	g.Expect(err).To(gomega.BeNil(), "Cannot fetch fybrikapplication")
@@ -1112,7 +1113,7 @@ func TestPlotterUpdate(t *testing.T) {
 	g.Expect(cl.Update(context.Background(), plotter)).NotTo(gomega.HaveOccurred())
 
 	// the new reconcile should update the application state
-	_, err = r.Reconcile(context.Background(), req)
+	_, err = r.Reconcile(context.Background(), newReq)
 	g.Expect(err).To(gomega.BeNil())
 	err = cl.Get(context.Background(), req.NamespacedName, application)
 	g.Expect(err).To(gomega.BeNil(), "Cannot fetch fybrikapplication")

--- a/manager/controllers/app/plotter_controller.go
+++ b/manager/controllers/app/plotter_controller.go
@@ -108,7 +108,7 @@ func (r *PlotterReconciler) reconcileFinalizers(ctx context.Context, plotter *ap
 			// remove the finalizer from the list and update it, because it needs to be deleted together with the object
 			ctrlutil.RemoveFinalizer(plotter, PlotterFinalizerName)
 
-			if err := utils.UpdateFinalizers(ctx, r.Client, plotter); err != nil {
+			if err := r.Client.Update(ctx, plotter); err != nil {
 				return err
 			}
 		}
@@ -117,7 +117,7 @@ func (r *PlotterReconciler) reconcileFinalizers(ctx context.Context, plotter *ap
 	// Make sure this CRD instance has a finalizer
 	if !hasFinalizer {
 		ctrlutil.AddFinalizer(plotter, PlotterFinalizerName)
-		if err := utils.UpdateFinalizers(ctx, r.Client, plotter); err != nil {
+		if err := r.Client.Update(ctx, plotter); err != nil {
 			return err
 		}
 	}
@@ -328,7 +328,7 @@ func (r *PlotterReconciler) reconcile(plotter *api.Plotter) (ctrl.Result, []erro
 	if plotter.Status.Blueprints == nil {
 		plotter.Status.Blueprints = make(map[string]api.MetaBlueprint)
 	}
-
+	logging.LogStructure("reconciling Plotter...", plotter, &log, zerolog.DebugLevel, false, true)
 	// Reset Assets state
 	assetToStatusMap := make(map[string]api.ObservedState)
 	plotter.Status.ObservedState.Error = "" // Reset error state

--- a/manager/controllers/utils/utils.go
+++ b/manager/controllers/utils/utils.go
@@ -153,27 +153,12 @@ func GetFybrikApplicationUUIDfromAnnotations(annotations map[string]string) stri
 	return uuid
 }
 
-// UpdateFinalizers adds or removes finalizers for a resource
-func UpdateFinalizers(ctx context.Context, cl client.Client, obj client.Object) error {
-	err := cl.Update(ctx, obj)
-	if !errors.IsConflict(err) {
-		return err
-	}
-	finalizers := obj.GetFinalizers()
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		// Retrieve the latest version of the object before attempting update
-		// RetryOnConflict uses exponential backoff to avoid exhausting the apiserver
-		if err := cl.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
-			return err
-		}
-		obj.SetFinalizers(finalizers)
-		return cl.Update(ctx, obj)
-	})
-}
-
 // UpdateStatus updates the resource status
 func UpdateStatus(ctx context.Context, cl client.Client, obj client.Object, previousStatus interface{}) error {
 	err := cl.Status().Update(ctx, obj)
+	if err == nil {
+		return nil
+	}
 	if !errors.IsConflict(err) {
 		return err
 	}

--- a/pkg/multicluster/local/local_cluster_manager.go
+++ b/pkg/multicluster/local/local_cluster_manager.go
@@ -87,6 +87,7 @@ func (cm *localClusterManager) UpdateBlueprint(cluster string, blueprint *v1alph
 	}
 	if _, err := ctrl.CreateOrUpdate(context.Background(), cm.Client, resource, func() error {
 		resource.Spec = blueprint.Spec
+		resource.ObjectMeta.Finalizers = blueprint.ObjectMeta.Finalizers
 		resource.ObjectMeta.Labels = blueprint.ObjectMeta.Labels
 		resource.ObjectMeta.Annotations = blueprint.ObjectMeta.Annotations
 		return nil


### PR DESCRIPTION
Signed-off-by: Shlomit Koyfman <shlomitk@il.ibm.com>
Fixes https://github.com/fybrik/fybrik/issues/1565

This PR does not perform unnecessary reconciles resulting in redundant plotter generation.
- Finalizers are patched instead of updating an entire object, thus the generation version does not change.
- Events coming from plotter updates have a "plotter_" prefix prepended to the app name, thus we can know clearly that the reconcile is caused by the plotter update.
- Since the plotter is generated before updating the app status, we get a "wrong" object when trying to obtain the FybrikApplication from the server. This PR checks that the status is consistent, i.e. a plotter update is received for an application that specified the plotter generation in the status. 