### PR TITLE
Provide a clear error message when storage accounts are not defined

### DIFF
--- a/manager/apis/app/v1alpha1/fybrikapplication_types.go
+++ b/manager/apis/app/v1alpha1/fybrikapplication_types.go
@@ -98,6 +98,7 @@ const (
 	ReadAccessDenied            string = "governance policies forbid access to the data"
 	CopyNotAllowed              string = "copy of the data is required but can not be done according to the governance policies"
 	WriteNotAllowed             string = "governance policies forbid writing of the data"
+	StorageAccountUndefined     string = "no storage account has been defined"
 	ModuleNotFound              string = "no module has been registered"
 	InsufficientStorage         string = "no bucket was provisioned for implicit copy"
 	InvalidClusterConfiguration string = "cluster configuration does not support the requirements"

--- a/manager/controllers/app/fybrikapplication_controller.go
+++ b/manager/controllers/app/fybrikapplication_controller.go
@@ -612,10 +612,17 @@ func (r *FybrikApplicationReconciler) checkGovernanceActions(configEvaluatorInpu
 			return err
 		}
 	}
+	accountRequired := (req.Context.Requirements.FlowParams.IsNewDataSet && configEvaluatorInput.Request.Usage == taxonomy.WriteFlow) ||
+		(configEvaluatorInput.Request.Usage == taxonomy.CopyFlow)
+	// no account is defined, return an error for write and copy flows
+	if len(env.StorageAccounts) == 0 {
+		if accountRequired {
+			return errors.New(api.StorageAccountUndefined)
+		}
+	}
 	// write is denied to all accounts, return Deny for write and copy flows
 	if len(req.StorageRequirements) == 0 {
-		if (req.Context.Requirements.FlowParams.IsNewDataSet && configEvaluatorInput.Request.Usage == taxonomy.WriteFlow) ||
-			(configEvaluatorInput.Request.Usage == taxonomy.CopyFlow) {
+		if accountRequired {
 			return errors.New(api.WriteNotAllowed)
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Shlomit Koyfman <shlomitk@il.ibm.com>
Fixes https://github.com/fybrik/fybrik/issues/1599

Changing error message for having no storage accounts for a copy or write flow.