### PR TITLE
Change webhook cert dir.

### DIFF
--- a/charts/fybrik/templates/manager-deployment.yaml
+++ b/charts/fybrik/templates/manager-deployment.yaml
@@ -141,13 +141,13 @@ spec:
               protocol: TCP
           {{- end }}
           volumeMounts:
-            {{- if .Values.clusterScoped }}
-            - mountPath: /tmp/k8s-webhook-server/serving-certs
-              name: cert
-              readOnly: true  
-            {{- end }}     
             - name: data
               mountPath: {{ include "fybrik.getDataDir" . }}
+           {{- if .Values.clusterScoped }}
+            - mountPath: {{ include "fybrik.getDataSubdir" (tuple "k8s-webhook-server" ) }}
+              name: cert
+              readOnly: true
+            {{- end }}
             - mountPath: {{ include "fybrik.getDataSubdir" ( tuple "taxonomy" ) }}
               name: fybrik-taxonomy
             - mountPath: {{ include "fybrik.getDataSubdir" ( tuple "adminconfig" ) }}

--- a/manager/main.go
+++ b/manager/main.go
@@ -42,6 +42,8 @@ import (
 	"fybrik.io/fybrik/pkg/storage"
 )
 
+const certSubDir = "/k8s-webhook-server"
+
 var (
 	gitCommit string
 	scheme    = kruntime.NewScheme()
@@ -53,8 +55,6 @@ func init() {
 	_ = corev1.AddToScheme(scheme)
 	_ = coordinationv1.AddToScheme(scheme)
 }
-
-var CertDir = environment.GetDataDir() + "/k8s-webhook-server"
 
 //nolint:funlen,gocyclo
 func run(namespace string, metricsAddr string, enableLeaderElection bool,
@@ -87,7 +87,7 @@ func run(namespace string, metricsAddr string, enableLeaderElection bool,
 	setupLog.Info().Msg("Manager client rate limits: qps = " + fmt.Sprint(client.QPS) + " burst=" + fmt.Sprint(client.Burst))
 
 	mgr, err := ctrl.NewManager(client, ctrl.Options{
-		CertDir:            CertDir,
+		CertDir:            environment.GetDataDir() + certSubDir,
 		Scheme:             scheme,
 		Namespace:          namespace,
 		MetricsBindAddress: metricsAddr,

--- a/manager/main.go
+++ b/manager/main.go
@@ -54,6 +54,8 @@ func init() {
 	_ = coordinationv1.AddToScheme(scheme)
 }
 
+var CertDir = environment.GetDataDir() + "/k8s-webhook-server"
+
 //nolint:funlen,gocyclo
 func run(namespace string, metricsAddr string, enableLeaderElection bool,
 	enableApplicationController, enableBlueprintController, enablePlotterController bool) int {
@@ -85,6 +87,7 @@ func run(namespace string, metricsAddr string, enableLeaderElection bool,
 	setupLog.Info().Msg("Manager client rate limits: qps = " + fmt.Sprint(client.QPS) + " burst=" + fmt.Sprint(client.Burst))
 
 	mgr, err := ctrl.NewManager(client, ctrl.Options{
+		CertDir:            CertDir,
 		Scheme:             scheme,
 		Namespace:          namespace,
 		MetricsBindAddress: metricsAddr,


### PR DESCRIPTION
This PR changes the webhook cert dir to be `/data` instead of `/tmp` similar to where the other data resides.

Reported by @roytman 