### PR TITLE
Add the wait flag to the helm uninstall command

### DIFF
--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -155,6 +155,8 @@ func NewHelmerImpl(chartsPath string) *Impl {
 // Uninstall helm release
 func (r *Impl) Uninstall(cfg *action.Configuration, releaseName string) (*release.UninstallReleaseResponse, error) {
 	uninstall := action.NewUninstall(cfg)
+	uninstall.Wait = true
+	uninstall.Timeout = TIMEOUT
 	return uninstall.Run(releaseName)
 }
 


### PR DESCRIPTION
Currently helm uninstall command returns whithout waiting for actual removing the release. 
This PR adds the `wait` flag, so helm will wait until teh release will be removed, or returns after timeout (5 mins)

/closes #1626 

Signed-off-by: Alexey Roytman <roytman@il.ibm.com>