### PR TITLE
fix print the ref of the last commit

### DIFF
--- a/connectors/katalog/Makefile
+++ b/connectors/katalog/Makefile
@@ -4,8 +4,7 @@ DOCKER_NAME = katalog-connector
 include $(ROOT_DIR)/Makefile.env
 include $(ROOT_DIR)/hack/make-rules/docker.mk
 include $(ROOT_DIR)/hack/make-rules/tools.mk
-
-GIT_COMMIT := $(shell git rev-list -1 HEAD)
+include $(ROOT_DIR)/hack/make-rules/version.mk
 
 .PHONY: all
 all: docker-build docker-push
@@ -17,7 +16,7 @@ docker-build: source-build
 
 .PHONY: source-build
 source-build:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -ldflags "-X main.gitCommit=$(GIT_COMMIT)" -o bin/katalog main.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build $(LDFLAGS) -o bin/katalog main.go
 
 .PHONY: run
 run:

--- a/connectors/katalog/Makefile
+++ b/connectors/katalog/Makefile
@@ -5,6 +5,8 @@ include $(ROOT_DIR)/Makefile.env
 include $(ROOT_DIR)/hack/make-rules/docker.mk
 include $(ROOT_DIR)/hack/make-rules/tools.mk
 
+GIT_COMMIT := $(shell git rev-list -1 HEAD)
+
 .PHONY: all
 all: docker-build docker-push
 
@@ -15,7 +17,7 @@ docker-build: source-build
 
 .PHONY: source-build
 source-build:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -o bin/katalog main.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -ldflags "-X main.gitCommit=$(GIT_COMMIT)" -o bin/katalog main.go
 
 .PHONY: run
 run:

--- a/connectors/katalog/main.go
+++ b/connectors/katalog/main.go
@@ -27,6 +27,8 @@ const (
 	envServicePort = "SERVICE_PORT"
 )
 
+var gitCommit string
+
 // RootCmd defines the root cli command
 func RootCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -72,6 +74,7 @@ func RunCmd() *cobra.Command {
 			}
 
 			handler := connector.NewHandler(client)
+			handler.Log.Info().Msg("based on git commit: " + gitCommit)
 			router := connector.NewRouter(handler)
 			router.Use(gin.Logger())
 			bindAddress := fmt.Sprintf("%s:%d", ip, port)

--- a/connectors/katalog/main.go
+++ b/connectors/katalog/main.go
@@ -27,7 +27,10 @@ const (
 	envServicePort = "SERVICE_PORT"
 )
 
-var gitCommit string
+var (
+	gitCommit string
+	gitTag    string
+)
 
 // RootCmd defines the root cli command
 func RootCmd() *cobra.Command {
@@ -74,7 +77,7 @@ func RunCmd() *cobra.Command {
 			}
 
 			handler := connector.NewHandler(client)
-			handler.Log.Info().Msg("based on git commit: " + gitCommit)
+			handler.Log.Info().Msg("based on: gitTag=" + gitTag + ", latest gitCommit=" + gitCommit)
 			router := connector.NewRouter(handler)
 			router.Use(gin.Logger())
 			bindAddress := fmt.Sprintf("%s:%d", ip, port)

--- a/connectors/opa/Makefile
+++ b/connectors/opa/Makefile
@@ -7,6 +7,7 @@ include $(ROOT_DIR)/hack/make-rules/tools.mk
 
 KUBE_NAMESPACE ?= fybrik-system
 POLICY_FILES ?=
+GIT_COMMIT := $(shell git rev-list -1 HEAD)
 
 .PHONY: all
 all: docker-build docker-push
@@ -18,7 +19,7 @@ docker-build: source-build
 
 .PHONY: source-build
 source-build:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -o opa-connector .
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -ldflags "-X main.gitCommit=$(GIT_COMMIT)" -o opa-connector .
 
 .PHONY: run
 run:

--- a/connectors/opa/Makefile
+++ b/connectors/opa/Makefile
@@ -4,10 +4,10 @@ DOCKER_NAME = opa-connector
 include $(ROOT_DIR)/Makefile.env
 include $(ROOT_DIR)/hack/make-rules/docker.mk
 include $(ROOT_DIR)/hack/make-rules/tools.mk
+include $(ROOT_DIR)/hack/make-rules/version.mk
 
 KUBE_NAMESPACE ?= fybrik-system
 POLICY_FILES ?=
-GIT_COMMIT := $(shell git rev-list -1 HEAD)
 
 .PHONY: all
 all: docker-build docker-push
@@ -19,7 +19,7 @@ docker-build: source-build
 
 .PHONY: source-build
 source-build:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -ldflags "-X main.gitCommit=$(GIT_COMMIT)" -o opa-connector .
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build $(LDFLAGS) -o opa-connector .
 
 .PHONY: run
 run:

--- a/connectors/opa/main.go
+++ b/connectors/opa/main.go
@@ -28,6 +28,8 @@ const (
 	envServicePort  = "SERVICE_PORT"
 )
 
+var gitCommit string
+
 // NewRouter returns a new router.
 func NewRouter(controller *ConnectorController) *gin.Engine {
 	router := gin.Default()
@@ -75,6 +77,7 @@ func RunCmd() *cobra.Command {
 
 			// Create and start connector
 			controller := NewConnectorController(opaServerURL)
+			controller.Log.Info().Msg("based on git commit: " + gitCommit)
 			router := NewRouter(controller)
 			router.Use(gin.Logger())
 

--- a/connectors/opa/main.go
+++ b/connectors/opa/main.go
@@ -28,7 +28,10 @@ const (
 	envServicePort  = "SERVICE_PORT"
 )
 
-var gitCommit string
+var (
+	gitCommit string
+	gitTag    string
+)
 
 // NewRouter returns a new router.
 func NewRouter(controller *ConnectorController) *gin.Engine {
@@ -77,7 +80,7 @@ func RunCmd() *cobra.Command {
 
 			// Create and start connector
 			controller := NewConnectorController(opaServerURL)
-			controller.Log.Info().Msg("based on git commit: " + gitCommit)
+			controller.Log.Info().Msg("based on: gitTag=" + gitTag + ", latest gitCommit=" + gitCommit)
 			router := NewRouter(controller)
 			router.Use(gin.Logger())
 

--- a/hack/make-rules/version.mk
+++ b/hack/make-rules/version.mk
@@ -1,0 +1,5 @@
+TAG := $(shell git describe --tags --abbrev=0)
+
+COMMIT := $(shell git rev-list -1 HEAD)
+
+LDFLAGS := -ldflags "-X main.gitCommit=$(COMMIT) -X main.gitTag=$(TAG)"

--- a/manager/Makefile
+++ b/manager/Makefile
@@ -8,25 +8,24 @@ DOCKER_NAME ?= manager
 KUBE_NAMESPACE ?= fybrik-system
 CONTROLLER_NAMESPACE ?= ${KUBE_NAMESPACE}
 
-GIT_COMMIT := $(shell git rev-list -1 HEAD)
-
 include $(ROOT_DIR)/hack/make-rules/tools.mk
 include $(ROOT_DIR)/hack/make-rules/docker.mk
 include $(ROOT_DIR)/hack/make-rules/verify.mk
+include $(ROOT_DIR)/hack/make-rules/version.mk
 
 # Build manager binary
 .PHONY: manager
 manager:
-	go build -ldflags "-X main.gitCommit=$(GIT_COMMIT)" -o bin/manager main.go
+	go build $(LDFLAGS) -o bin/manager main.go
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 .PHONY: run
 run:
-	go run -ldflags "-X main.gitCommit=$(GIT_COMMIT)" ./main.go --enable-all-controllers --metrics-bind-addr=0
+	go run ./main.go --enable-all-controllers --metrics-bind-addr=0
 
 .PHONY: source-build
 source-build:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -ldflags "-X main.gitCommit=$(GIT_COMMIT)" -o manager main.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build $(LDFLAGS) -o manager main.go
 
 # Overwrite docker-build from docker.mk
 .PHONY: docker-build

--- a/manager/Makefile
+++ b/manager/Makefile
@@ -26,7 +26,7 @@ run:
 
 .PHONY: source-build
 source-build:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -o manager main.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -ldflags "-X main.gitCommit=$(GIT_COMMIT)" -o manager main.go
 
 # Overwrite docker-build from docker.mk
 .PHONY: docker-build

--- a/manager/main.go
+++ b/manager/main.go
@@ -46,6 +46,7 @@ const certSubDir = "/k8s-webhook-server"
 
 var (
 	gitCommit string
+	gitTag    string
 	scheme    = kruntime.NewScheme()
 	setupLog  = logging.LogInit(logging.SETUP, "main")
 )
@@ -59,7 +60,7 @@ func init() {
 //nolint:funlen,gocyclo
 func run(namespace string, metricsAddr string, enableLeaderElection bool,
 	enableApplicationController, enableBlueprintController, enablePlotterController bool) int {
-	setupLog.Info().Msg("creating manager. based on git commit: " + gitCommit)
+	setupLog.Info().Msg("creating manager. based on: gitTag=" + gitTag + ", latest gitCommit=" + gitCommit)
 	environment.LogEnvVariables(&setupLog)
 
 	var applicationNamespaceSelector fields.Selector


### PR DESCRIPTION
Fixes print the reference of the last commit in manager, add it to OPA and Katalog connectors. 

/closes #1638 

Signed-off-by: Alexey Roytman <roytman@il.ibm.com>