### PR TITLE
Remove the tag of image and use the latest tag by default

### DIFF
--- a/connectors/katalog/Dockerfile
+++ b/connectors/katalog/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 ENV HOME=/tmp
 WORKDIR /tmp

--- a/connectors/opa/Dockerfile
+++ b/connectors/opa/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 ENV HOME=/tmp
 WORKDIR /tmp

--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2020 IBM Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 ENV HOME=/tmp
 WORKDIR $HOME
 COPY manager /

--- a/pkg/optimizer/Dockerfile
+++ b/pkg/optimizer/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2022 IBM Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 ENV HOME=/data
 WORKDIR /data
 COPY solver-tools /data/tools

--- a/samples/rest-server/Dockerfile
+++ b/samples/rest-server/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2020 IBM Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 ENV HOME=/tmp
 WORKDIR /tmp
 

--- a/test/services/datacatalog/Dockerfile
+++ b/test/services/datacatalog/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 ENV HOME=/tmp
 WORKDIR /tmp
 

--- a/test/services/policymanager/Dockerfile
+++ b/test/services/policymanager/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 ENV HOME=/tmp
 WORKDIR /tmp


### PR DESCRIPTION
Without the tag, docker will pull the latest image of `ubi8/ubi-minimal`

We don't need manully bump the version later.

Signed-off-by: Hui Yu <ityuhui@gmail.com>