### PR TITLE
Fix handling of TLS CA certificates.

### DIFF
--- a/charts/fybrik/values.yaml
+++ b/charts/fybrik/values.yaml
@@ -179,6 +179,9 @@ manager:
       certSecretNamespace: ""
       # Name of kubernetes secret that holds the certificate authority (CA) certificates
       # which are used by the manager to validate the connection to the connectors.
+      # The provided certificates are used along with the certificates in the system CA certificate store.
+      # If the secret is not provided then the CA certificates are taken from the system
+      # CA certificate store, for example `/etc/ssl/certs/`.
       # cacertSecretName: "test-tls-ca-certs"
       cacertSecretName: ""
       # Name of kubernetes secret namespace that holds the certificate authority (CA)
@@ -379,6 +382,9 @@ katalogConnector:
       certSecretNamespace: ""
       # Name of kubernetes secret that holds the certificate authority (CA) certificate which is used
       # by katalog-connector to validate the connection to the manager if mtls is enabled.
+      # The provided certificates are used along with the certificates in the system CA certificate store.
+      # If the secret is not provided then the CA certificates are taken from the system
+      # CA certificate store, for example `/etc/ssl/certs/`.
       # cacertSecretName: "test-tls-ca-certs"
       cacertSecretName: ""
       # Name of kubernetes secret namespace that holds the certificate authority (CA) certificate which
@@ -474,6 +480,9 @@ opaConnector:
       certSecretNamespace: ""
       # Name of kubernetes secret that holds the certificate authority (CA) certificate which is used
       # by opa-connector to validate the connection to the manager if mtls is enabled.
+      # The provided certificates are used along with the certificates in the system CA certificate store.
+      # If the secret is not provided then the CA certificates are taken from the system
+      # CA certificate store, for example `/etc/ssl/certs/`.
       # cacertSecretName: "test-tls-ca-certs"
       cacertSecretName: ""
       # Name of kubernetes secret namespace that holds the certificate authority (CA) certificate which


### PR DESCRIPTION
In the current implementation of TLS communication between the manager and connector, it is assumed that CA certificates must be provided for the client (aka manager) and are expected to be set for the servers (aka connectors) if mutual TLS is used. This is not correct as the system CA certificates are used by default (found in directory`/etc/ssl/certs/` for example) if a private one is not provided. 
This PR fixes this behavior.