### PR TITLE
Fix a misleading statement in the manager-deployment.yaml` file

### DIFF
--- a/charts/fybrik/templates/manager-deployment.yaml
+++ b/charts/fybrik/templates/manager-deployment.yaml
@@ -16,10 +16,9 @@ spec:
       {{- include "fybrik.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.manager.podAnnotations }}
+      {{- if .Values.manager.podAnnotations }}
       annotations:
-        sidecar.istio.io/inject: "true"
-        {{- toYaml . | nindent 8 }}
+      {{- .Values.manager.podAnnotations | toYaml | nindent 8 }}
       {{- end }}
       labels:
         control-plane: controller-manager

--- a/charts/fybrik/values.yaml
+++ b/charts/fybrik/values.yaml
@@ -204,7 +204,8 @@ manager:
     # The name of the service account to use
     name: manager
 
-  podAnnotations: {}
+  podAnnotations:
+    sidecar.istio.io/inject: "true"
 
   # Pod Security Context. If set, the fields of podSecurityContext override
   # the equivalent fields of .Values.global.podSecurityContext.

--- a/charts/fybrik/values.yaml
+++ b/charts/fybrik/values.yaml
@@ -204,8 +204,9 @@ manager:
     # The name of the service account to use
     name: manager
 
-  podAnnotations:
-    sidecar.istio.io/inject: "true"
+  podAnnotations: {}
+  #  To enable Istio automatic sidecar injection add:
+  #  sidecar.istio.io/inject: "true"
 
   # Pod Security Context. If set, the fields of podSecurityContext override
   # the equivalent fields of .Values.global.podSecurityContext.


### PR DESCRIPTION
closes #1665 

This PR adds  annotations if such exists in `.Values.manager.podAnnotations`. 

The  `sidecar.istio.io/inject: "true"` exists as default annotation. it is need for sidecar injection for the manager if istio is needed.