### PR TITLE
give access to vault secrets to pods in the fybrik-system namespace

### DIFF
--- a/charts/vault/templates/post-pod-creation-cm.yaml
+++ b/charts/vault/templates/post-pod-creation-cm.yaml
@@ -26,6 +26,8 @@ data:
       EOF
       # allow modules running in fybrik-blueprints namespace to access dataset credentials
       vault write auth/kubernetes/role/module bound_service_account_names="*" bound_service_account_namespaces="{{ .Values.modulesNamespace }}" policies="allow-all-dataset-creds" ttl=24h
+      # allow modules running in fybrik-system namespace to access dataset credentials
+      vault write auth/kubernetes/role/fybrik bound_service_account_names="*" bound_service_account_namespaces="{{ .Release.Namespace }}" policies="allow-all-dataset-creds" ttl=24h
       # enable userpass auth method
       vault auth enable userpass
       vault write auth/userpass/users/data_provider password=password policies="allow-all-dataset-creds"

--- a/site/docs/concepts/connectors.md
+++ b/site/docs/concepts/connectors.md
@@ -37,7 +37,7 @@ The connector might need to read credentials stored in HashiCorp Vault. The para
 
 * address: Vault address
 * authPath: Path to [`kubernetes` auth method](https://www.vaultproject.io/docs/auth/kubernetes) used to login to Vault
-* role: connector role used to login to Vault
+* role: connector role used to login to Vault - configured to be "fybrik"
 * secretPath: Path of the secret holding the credentials in Vault
 
 The parameters should be known to the connector upon startup time except from the vault secret path (`SecretPath`) which is passed as a parameter in each call to the connector usually under `Credentials` name.


### PR DESCRIPTION
To be used by data-catalog connectors.

Signed-off-by: Doron Chen <cdoron@il.ibm.com>