### PR TITLE
git command does not return the latest stable version 

### DIFF
--- a/hack/make-rules/version.mk
+++ b/hack/make-rules/version.mk
@@ -1,4 +1,4 @@
-TAG := $(shell git describe --tags --abbrev=0)
+TAG := $(shell git for-each-ref --format="%(refname:short)" --sort=-authordate --count=1 refs/tags)
 
 COMMIT := $(shell git rev-list -1 HEAD)
 


### PR DESCRIPTION
I have fetched all latest tags from [upstream](https://github.com/fybrik/fybrik) repo to my [local fork](https://github.com/rohithdv/fybrik). 
<img width="403" alt="image" src="https://user-images.githubusercontent.com/59818576/186649446-9d4fd00d-70e0-49d6-993c-585c446382bc.png">

Now when I do `docker-build` in `fybrik/manager` folder, I get the following: 
<img width="1317" alt="image" src="https://user-images.githubusercontent.com/59818576/186649557-6edb37ad-05c6-457a-b3ac-68bd75c881b4.png">

The latest tag is not being picked up. I have changed the git command to return the latest stable tag as suggested [here](https://github.com/jquery/jquery/issues/1854) in this PR.
The updated output is given below. 
<img width="1338" alt="image" src="https://user-images.githubusercontent.com/59818576/186649830-8d4b8199-0745-455e-9e5b-dcb7812d0c7b.png">
 

Signed-off-by: Rohith D Vallam <rovallam@in.ibm.com>