### PR TITLE
add configurable discoveryBurst and discoveryQPS

### DIFF
--- a/charts/fybrik/templates/fybrik-config.yaml
+++ b/charts/fybrik/templates/fybrik-config.yaml
@@ -8,6 +8,8 @@ data:
   LOGGING_VERBOSITY: {{ .Values.global.loggingVerbosity | quote }}
   RESOURCE_POLLING_INTERVAL: {{ .Values.manager.resourcePollingInterval | quote }}
   HELM_WAIT_TIMEOUT: {{ .Values.manager.helmWaitTimeout | quote }}
+  DISCOVERY_BURST: {{ .Values.manager.discoveryBurst | quote }}
+  DISCOVERY_QPS: {{ .Values.manager.discoveryQPS | quote }}
   MIN_TLS_VERSION:  {{ .Values.manager.tls.minVersion }}
   {{- if .Values.coordinator.enabled }}
   DATAPATH_MAX_SIZE: {{ .Values.manager.dataPathMaxSize | quote }}

--- a/charts/fybrik/values.yaml
+++ b/charts/fybrik/values.yaml
@@ -171,6 +171,16 @@ manager:
   # Default value is 200 seconds.
   helmWaitTimeout: 200
 
+  # Allows increasing burst used for discovery, this is useful in clusters with many registered resources
+  # Fybrik manager uses it during modules helm operations
+  # value is int
+  discoveryBurst: ""
+
+  # Allows increasing qps used for discovery, this is useful in clusters with many registered resources
+  # Fybrik manager uses it during modules helm operations
+  # value is float32
+  discoveryQPS: ""
+
   tls:
     # Relavent if the connection between the manager and one of the connectors
     # uses tls.

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -188,7 +188,14 @@ func GetDiscoveryBurst() (int, error) {
 	if burstStr == "" {
 		return -1, nil
 	}
-	return strconv.Atoi(burstStr)
+	burst, err := strconv.Atoi(burstStr)
+	if err != nil {
+		return -1, err
+	}
+	if burst <= 0 {
+		return -1, fmt.Errorf("discovery burst should be positive, got %d", burst)
+	}
+	return burst, err
 }
 
 // GetDiscoveryQPS returns the K8s discovery QPS value if it is set, otherwise it returns -1
@@ -199,10 +206,13 @@ func GetDiscoveryQPS() (float32, error) {
 	}
 	//nolint:revive,gomnd // ignore magic numbers
 	qps, err := strconv.ParseFloat(qpsStr, 32)
-	if err == nil {
-		return float32(qps), nil
+	if err != nil {
+		return -1, err
 	}
-	return -1, err
+	if qps <= 0 {
+		return -1, fmt.Errorf("discovery QPS should be positive, got %f", qps)
+	}
+	return float32(qps), err
 }
 
 // GetVaultAddress returns the address and port of the vault system,


### PR DESCRIPTION
Allows to configure discovery K8s client parameters for helm operations.
/closes 1740

Signed-off-by: Alexey Roytman <roytman@il.ibm.com>