### PR TITLE
simplify OM installation.

### DIFF
--- a/third_party/openmetadata/Makefile
+++ b/third_party/openmetadata/Makefile
@@ -43,7 +43,8 @@ spec:
     spec:
       containers:
       - name: prepare-openmetadata
-        image: 'ghcr.io/fybrik/prepare-openmetadata:0.0.0'
+        image: 'ghcr.io/fybrik/openmetadata-connector:0.0.0'
+        command: ["/openmetadata-connector", "prepare", "--customization", "/customization.yaml"]
         env:
         - name: OPENMETADATA_ENDPOINT
           value: http://openmetadata.$(INSTALLATION_NAMESPACE):8585/api


### PR DESCRIPTION
A separate openmetadata-connector docker image is not needed

Signed-off-by: Doron Chen <cdoron@il.ibm.com>