### PR TITLE
Add blocking to flight module call in fybrik_notebook_write_flow_test…

### DIFF
--- a/manager/controllers/app/fybrik_notebook_write_flow_test.go
+++ b/manager/controllers/app/fybrik_notebook_write_flow_test.go
@@ -355,7 +355,7 @@ func TestS3NotebookWriteFlow(t *testing.T) {
 
 	// Reading data via arrow flight
 	opts = make([]grpc.DialOption, 0)
-	opts = append(opts, grpc.WithInsecure())
+	opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock(), grpc.WithTimeout(timeout))
 	flightClient, err = flight.NewFlightClient(net.JoinHostPort("localhost", listenPort), nil, opts...)
 	g.Expect(err).To(gomega.BeNil(), "Connect to arrow-flight service")
 	defer flightClient.Close()


### PR DESCRIPTION
….go.

This PR is a missing part from https://github.com/fybrik/fybrik/pull/1693 and should fix "Fix "connection closed before server preface receive" error in notebook write test.

Signed-off-by: Revital Sur <eres@il.ibm.com>