### PR TITLE
Add missing check for empty response from data catalog.

### DIFF
--- a/pkg/connectors/datacatalog/clients/datacatalog_openapi.go
+++ b/pkg/connectors/datacatalog/clients/datacatalog_openapi.go
@@ -56,8 +56,16 @@ func NewOpenAPIDataCatalog(name, connectionURL string) DataCatalog {
 }
 
 func (m *openAPIDataCatalog) GetAssetInfo(in *datacatalog.GetAssetRequest, creds string) (*datacatalog.GetAssetResponse, error) {
+	printErr := fmt.Sprintf("get asset info from %s failed", m.name)
+
 	resp, httpResponse, err :=
 		m.client.DefaultApi.GetAssetInfo(context.Background()).XRequestDatacatalogCred(creds).GetAssetRequest(*in).Execute()
+	if httpResponse == nil {
+		if err != nil {
+			return nil, errors.Wrap(err, printErr)
+		}
+		return nil, errors.New(printErr)
+	}
 	defer httpResponse.Body.Close()
 	if httpResponse.StatusCode == http.StatusForbidden {
 		return nil, errors.New(AccessForbidden)
@@ -66,32 +74,48 @@ func (m *openAPIDataCatalog) GetAssetInfo(in *datacatalog.GetAssetRequest, creds
 		return nil, errors.New(AssetIDNotFound)
 	}
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("get asset info from %s failed", m.name))
+		return nil, errors.Wrap(err, printErr)
 	}
 	return resp, nil
 }
 
 func (m *openAPIDataCatalog) CreateAsset(in *datacatalog.CreateAssetRequest, creds string) (*datacatalog.CreateAssetResponse, error) {
+	printErr := fmt.Sprintf("create asset info from %s failed", m.name)
 	resp, httpResponse, err := m.client.DefaultApi.CreateAsset(context.Background()).
 		XRequestDatacatalogWriteCred(creds).CreateAssetRequest(*in).Execute()
+	if httpResponse == nil {
+		if err != nil {
+			return nil, errors.Wrap(err, printErr)
+		}
+		return nil, errors.New(printErr)
+	}
 	defer httpResponse.Body.Close()
+
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("create asset info from %s failed", m.name))
+		return nil, errors.Wrap(err, printErr)
 	}
 	return resp, nil
 }
 
 //nolint:dupl
 func (m *openAPIDataCatalog) DeleteAsset(in *datacatalog.DeleteAssetRequest, creds string) (*datacatalog.DeleteAssetResponse, error) {
+	printErr := fmt.Sprintf("delete asset info from %s failed", m.name)
 	resp, httpResponse, err :=
 		m.client.DefaultApi.DeleteAsset(context.Background()).XRequestDatacatalogCred(creds).DeleteAssetRequest(*in).Execute()
+	if httpResponse == nil {
+		if err != nil {
+			return nil, errors.Wrap(err, printErr)
+		}
+		return nil, errors.New(printErr)
+	}
 	defer httpResponse.Body.Close()
 	if httpResponse.StatusCode == http.StatusNotFound {
 		return nil, errors.New(AssetIDNotFound)
 	}
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("delete asset info from %s failed", m.name))
+		return nil, errors.Wrap(err, printErr)
 	}
+
 	return resp, nil
 }
 
@@ -99,12 +123,19 @@ func (m *openAPIDataCatalog) DeleteAsset(in *datacatalog.DeleteAssetRequest, cre
 func (m *openAPIDataCatalog) UpdateAsset(in *datacatalog.UpdateAssetRequest, creds string) (*datacatalog.UpdateAssetResponse, error) {
 	resp, httpResponse, err := m.client.DefaultApi.UpdateAsset(
 		context.Background()).XRequestDatacatalogUpdateCred(creds).UpdateAssetRequest(*in).Execute()
+	printErr := fmt.Sprintf("update asset info from %s failed", m.name)
+	if httpResponse == nil {
+		if err != nil {
+			return nil, errors.Wrap(err, printErr)
+		}
+		return nil, errors.New(printErr)
+	}
 	defer httpResponse.Body.Close()
 	if httpResponse.StatusCode == http.StatusNotFound {
 		return nil, errors.New(AssetIDNotFound)
 	}
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("update asset info from %s failed", m.name))
+		return nil, errors.Wrap(err, printErr)
 	}
 	return resp, nil
 }


### PR DESCRIPTION
This PR fixes cases where the httpResponse from the data catalog is empty, for example, when an error such as `tls: server selected unsupported protocol version 303` occurs, indicating an unsupported tls version. (in java 1.8, the minimum tls version is 1.2, while the manager default value is 1.3, so when the datacatalog server is implemented in java there will be a mismatch)
In this case, the manager fails with a fatal error after executing `defer httpResponse.Body.Close()`