### PR TITLE
update openmetadata-connector version to 0.2.0

### DIFF
--- a/charts/fybrik/values.yaml
+++ b/charts/fybrik/values.yaml
@@ -535,7 +535,7 @@ openmetadataConnector:
   enabled: auto
 
   # Image name or a hub/image[:tag]
-  image: "ghcr.io/fybrik/openmetadata-connector:0.1.0"
+  image: "ghcr.io/fybrik/openmetadata-connector:0.2.0"
 
   # Overrides global.imagePullPolicy
   imagePullPolicy: "Always"


### PR DESCRIPTION
to support generic assets
for the module chaining sample

Signed-off-by: Doron Chen <cdoron@il.ibm.com>