### PR TITLE
Fix handling of CATALOGED_ASSET env var in notebook sample test runs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,6 @@ export COPY_TEST_CACERTS ?= 0
 # Vault is configured in commands executed during Vault helm chart
 # deployment.
 export RUN_VAULT_CONFIGURATION_SCRIPT ?= 1
-# Deploy openmetadata catalog in tests
-export DEPLOY_OPENMETADATA ?= 0
 
 .PHONY: all
 all: generate manifests generate-docs verify

--- a/manager/controllers/app/fybrik_notebook_read_flow_test.go
+++ b/manager/controllers/app/fybrik_notebook_read_flow_test.go
@@ -48,10 +48,7 @@ func TestS3NotebookReadFlow(t *testing.T) {
 		t.Skip("Only executed for notebook tests")
 	}
 	catalogedAsset, ok := os.LookupEnv("CATALOGED_ASSET")
-	if !ok {
-		t.Skip("Error getting CATALOGED_ASSET env var")
-	}
-	if catalogedAsset == "" {
+	if !ok || catalogedAsset == "" {
 		// Use default value which assumes katalog catalog is deployed
 		catalogedAsset = "fybrik-notebook-sample/data-csv"
 	}


### PR DESCRIPTION
This PR fixes recent bug in notebook tests which are skipped due to an [error](https://github.com/fybrik/fybrik/actions/runs/3462508631/jobs/5781489800): 

```
fybrik_notebook_read_flow_test.go:52: Error getting CATALOGED_ASSET env var