### PR TITLE
bump base image to ubi-minimal:8.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ run-notebook-readflow-tls-tests:
 
 .PHONY: run-notebook-readflow-tls-system-cacerts-tests
 run-notebook-readflow-tls-system-cacerts-tests: export VALUES_FILE=charts/fybrik/notebook-test-readflow.tls-system-cacerts.yaml
-run-notebook-readflow-tls-system-cacerts-tests: export FROM_IMAGE=registry.access.redhat.com/ubi8/ubi:8.6
+run-notebook-readflow-tls-system-cacerts-tests: export FROM_IMAGE=registry.access.redhat.com/ubi8/ubi:8.7
 run-notebook-readflow-tls-system-cacerts-tests: export DEPLOY_TLS_TEST_CERTS=1
 run-notebook-readflow-tls-system-cacerts-tests: export COPY_TEST_CACERTS=1
 run-notebook-readflow-tls-system-cacerts-tests:

--- a/connectors/katalog/Dockerfile
+++ b/connectors/katalog/Dockerfile
@@ -1,4 +1,4 @@
-ARG image=registry.access.redhat.com/ubi8/ubi-minimal:8.6
+ARG image=registry.access.redhat.com/ubi8/ubi-minimal:8.7
 FROM $image
 
 ENV HOME=/tmp

--- a/connectors/opa/Dockerfile
+++ b/connectors/opa/Dockerfile
@@ -1,4 +1,4 @@
-ARG image=registry.access.redhat.com/ubi8/ubi-minimal:8.6
+ARG image=registry.access.redhat.com/ubi8/ubi-minimal:8.7
 FROM $image
 
 ENV HOME=/tmp

--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright 2020 IBM Corp.
 # SPDX-License-Identifier: Apache-2.0
-ARG image=registry.access.redhat.com/ubi8/ubi-minimal:8.6
+ARG image=registry.access.redhat.com/ubi8/ubi-minimal:8.7
 FROM $image
 ENV HOME=/tmp
 WORKDIR $HOME

--- a/pkg/optimizer/Dockerfile
+++ b/pkg/optimizer/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2022 IBM Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
 ENV HOME=/data
 WORKDIR /data
 COPY solver-tools /data/tools

--- a/samples/rest-server/Dockerfile
+++ b/samples/rest-server/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2020 IBM Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
 ENV HOME=/tmp
 WORKDIR /tmp
 

--- a/test/services/datacatalog/Dockerfile
+++ b/test/services/datacatalog/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
 ENV HOME=/tmp
 WORKDIR /tmp
 

--- a/test/services/policymanager/Dockerfile
+++ b/test/services/policymanager/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
 
 ENV HOME=/tmp
 WORKDIR /tmp


### PR DESCRIPTION
Resolve the following vulnerabilities:
- CVE-2022-1304
- CVE-2016-3709
- CVE-2022-42898

```bash
The scan results show that 3 ISSUES were found for the image.

Vulnerable Packages Found
=========================

Vulnerability ID   Policy Status   Affected Packages   How to Resolve
CVE-2022-1304      Active          libcom_err          Upgrade libcom_err to >= 1.45.6-5.el8
CVE-2016-3709      Active          libxml2             Upgrade libxml2 to >= 2.9.7-15.el8
CVE-2022-42898     Active          krb5-libs           Upgrade krb5-libs to >= 1.18.2-22.el8_7
```