### PR TITLE
A skeleton for handling multiple implementations of storage allocation/deletion based on the storage type

### DIFF
--- a/pkg/storage/impl/mysql/mysql_impl.go
+++ b/pkg/storage/impl/mysql/mysql_impl.go
@@ -1,0 +1,50 @@
+// Copyright 2023 IBM Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+package mysql
+
+import (
+	"github.com/rs/zerolog"
+
+	fappv1 "fybrik.io/fybrik/manager/apis/app/v1beta1"
+	fappv2 "fybrik.io/fybrik/manager/apis/app/v1beta2"
+	"fybrik.io/fybrik/pkg/logging"
+	"fybrik.io/fybrik/pkg/model/taxonomy"
+	"fybrik.io/fybrik/pkg/storage/registrator"
+	"fybrik.io/fybrik/pkg/storage/registrator/agent"
+)
+
+// Storage manager implementation for MySQL
+type MySQLImpl struct {
+	Name taxonomy.ConnectionType
+	Log  zerolog.Logger
+}
+
+// implementation of AgentInterface for MySQL
+func NewMySQLImpl() *MySQLImpl {
+	return &MySQLImpl{Name: "mysql", Log: logging.LogInit(logging.CONNECTOR, "StorageManager")}
+}
+
+// register the implementation for MySQL
+func init() {
+	mysqlImpl := NewMySQLImpl()
+	if err := registrator.Register(mysqlImpl); err != nil {
+		mysqlImpl.Log.Error().Err(err)
+	}
+}
+
+// return the supported connection type
+func (impl *MySQLImpl) GetConnectionType() taxonomy.ConnectionType {
+	return impl.Name
+}
+
+// storage allocation - placeholder
+func (impl *MySQLImpl) AllocateStorage(account *fappv2.FybrikStorageAccountSpec,
+	secret *fappv1.SecretRef, opts *agent.Options) (taxonomy.Connection, error) {
+	return taxonomy.Connection{Name: impl.Name}, nil
+}
+
+// storage deletion - placeholder
+func (impl *MySQLImpl) DeleteStorage(connection *taxonomy.Connection, secret *fappv1.SecretRef, opts *agent.Options) error {
+	return nil
+}

--- a/pkg/storage/impl/s3/s3_impl.go
+++ b/pkg/storage/impl/s3/s3_impl.go
@@ -1,0 +1,49 @@
+// Copyright 2023 IBM Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+package s3
+
+import (
+	"github.com/rs/zerolog"
+
+	fappv1 "fybrik.io/fybrik/manager/apis/app/v1beta1"
+	fappv2 "fybrik.io/fybrik/manager/apis/app/v1beta2"
+	"fybrik.io/fybrik/pkg/logging"
+	"fybrik.io/fybrik/pkg/model/taxonomy"
+	registrator "fybrik.io/fybrik/pkg/storage/registrator"
+	agent "fybrik.io/fybrik/pkg/storage/registrator/agent"
+)
+
+// s3 storage manager implementaton
+type S3Impl struct {
+	Name taxonomy.ConnectionType
+	Log  zerolog.Logger
+}
+
+func NewS3Impl() *S3Impl {
+	return &S3Impl{Name: "s3", Log: logging.LogInit(logging.CONNECTOR, "StorageManager")}
+}
+
+// register the implementation for s3
+func init() {
+	s3Impl := NewS3Impl()
+	if err := registrator.Register(s3Impl); err != nil {
+		s3Impl.Log.Error().Err(err)
+	}
+}
+
+// return the supported connection type
+func (impl *S3Impl) GetConnectionType() taxonomy.ConnectionType {
+	return impl.Name
+}
+
+// allocate storage for s3 - placeholder
+func (impl *S3Impl) AllocateStorage(account *fappv2.FybrikStorageAccountSpec, secret *fappv1.SecretRef,
+	opts *agent.Options) (taxonomy.Connection, error) {
+	return taxonomy.Connection{Name: impl.Name}, nil
+}
+
+// delete s3 storage - placeholder
+func (impl *S3Impl) DeleteStorage(connection *taxonomy.Connection, secret *fappv1.SecretRef, opts *agent.Options) error {
+	return nil
+}

--- a/pkg/storage/registrator/agent/agent.go
+++ b/pkg/storage/registrator/agent/agent.go
@@ -1,0 +1,50 @@
+// Copyright 2023 IBM Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+package agent
+
+import (
+	"k8s.io/apimachinery/pkg/types"
+
+	fappv1 "fybrik.io/fybrik/manager/apis/app/v1beta1"
+	fappv2 "fybrik.io/fybrik/manager/apis/app/v1beta2"
+	"fybrik.io/fybrik/pkg/model/taxonomy"
+)
+
+// Details of the owner application
+type ApplicationDetails struct {
+	// Name and namespace
+	Owner *types.NamespacedName
+	// uuid
+	UUID string
+}
+
+// Details of the new asset
+// The current implementation includes only a name provided in the write flow for a new asset
+type DatasetDetails struct {
+	Name string
+}
+
+// Configuration options
+// TODO: extend IT config policies to return options for storage management
+type ConfigOptions struct {
+	// Delete an empty folder/bucket when the allocated storage is deleted
+	DeleteEmptyFolder bool
+}
+
+// Additional options provided for storage allocation/deletion
+type Options struct {
+	AppDetails        ApplicationDetails
+	DatasetProperties DatasetDetails
+	ConfigurationOpts ConfigOptions
+}
+
+// agent interface for managing storage for a supported connection type
+type AgentInterface interface {
+	// allocate storage
+	AllocateStorage(account *fappv2.FybrikStorageAccountSpec, secret *fappv1.SecretRef, opts *Options) (taxonomy.Connection, error)
+	// delete storage
+	DeleteStorage(connection *taxonomy.Connection, secret *fappv1.SecretRef, opts *Options) error
+	// return the supported connection type
+	GetConnectionType() taxonomy.ConnectionType
+}

--- a/pkg/storage/registrator/registrator.go
+++ b/pkg/storage/registrator/registrator.go
@@ -1,0 +1,52 @@
+// Copyright 2023 IBM Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+package registrator
+
+import (
+	"errors"
+	"sync"
+
+	"fybrik.io/fybrik/pkg/model/taxonomy"
+	"fybrik.io/fybrik/pkg/storage/registrator/agent"
+)
+
+var (
+	agentsMu sync.RWMutex
+	// map of implementation agents by the connection types they support
+	agents = make(map[taxonomy.ConnectionType]agent.AgentInterface)
+)
+
+// register a new implementation agent
+func Register(worker agent.AgentInterface) error {
+	// mutex for the writing operation
+	agentsMu.Lock()
+	defer agentsMu.Unlock()
+	if worker == nil {
+		return errors.New("attemting to register a nil object")
+	}
+	key := worker.GetConnectionType()
+	if _, dup := agents[key]; dup {
+		return errors.New("attempting to register an agent for an existing connection type")
+	}
+	agents[key] = worker
+	return nil
+}
+
+// return the appropriate agent
+func GetAgent(key taxonomy.ConnectionType) (agent.AgentInterface, error) {
+	worker, exists := agents[key]
+	if !exists {
+		return nil, errors.New("unsupported connection type " + string(key))
+	}
+	return worker, nil
+}
+
+// return the registered connection types
+func GetRegisteredTypes() []taxonomy.ConnectionType {
+	res := make([]taxonomy.ConnectionType, 0)
+	for connType := range agents {
+		res = append(res, connType)
+	}
+	return res
+}

--- a/pkg/storage/storage_manager.go
+++ b/pkg/storage/storage_manager.go
@@ -1,0 +1,51 @@
+// Copyright 2023 IBM Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+package storage
+
+import (
+	"errors"
+
+	fappv1 "fybrik.io/fybrik/manager/apis/app/v1beta1"
+	fappv2 "fybrik.io/fybrik/manager/apis/app/v1beta2"
+	"fybrik.io/fybrik/pkg/model/taxonomy"
+	"fybrik.io/fybrik/pkg/storage/registrator"
+	"fybrik.io/fybrik/pkg/storage/registrator/agent"
+
+	// Registration of the implementation agents is done by adding blank imports which invoke init() method of each package
+	_ "fybrik.io/fybrik/pkg/storage/impl/mysql"
+	_ "fybrik.io/fybrik/pkg/storage/impl/s3"
+)
+
+// internal implementation of StorageManager APIs
+// OpenAPI - TBD
+
+// AllocateStorage allocates storage based on the selected storage account by invoking the specific implementation agent
+// returns a Connection object in case of success, and an error - otherwise
+func AllocateStorage(account *fappv2.FybrikStorageAccountSpec, secret *fappv1.SecretRef, opts *agent.Options) (taxonomy.Connection, error) {
+	if account == nil {
+		return taxonomy.Connection{}, errors.New("invalid storage account")
+	}
+	impl, err := registrator.GetAgent(account.Type)
+	if err != nil {
+		return taxonomy.Connection{}, err
+	}
+	return impl.AllocateStorage(account, secret, opts)
+}
+
+// DeleteStorage deletes the existing storage by invoking the specific implementation agent based on the connection type
+func DeleteStorage(connection *taxonomy.Connection, secret *fappv1.SecretRef, opts *agent.Options) error {
+	if connection == nil {
+		return errors.New("invalid connection object")
+	}
+	impl, err := registrator.GetAgent(connection.Name)
+	if err != nil {
+		return err
+	}
+	return impl.DeleteStorage(connection, secret, opts)
+}
+
+// retun a list of supported connection types
+func GetSupportedConnectionTypes() []taxonomy.ConnectionType {
+	return registrator.GetRegisteredTypes()
+}

--- a/pkg/storage/storage_manager_test.go
+++ b/pkg/storage/storage_manager_test.go
@@ -1,0 +1,32 @@
+// Copyright 2023 IBM Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+package storage
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+
+	"fybrik.io/fybrik/manager/apis/app/v1beta2"
+	"fybrik.io/fybrik/pkg/model/taxonomy"
+)
+
+// test that the implementation agents have been registered successfully
+func TestSupportedConnections(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewGomegaWithT(t)
+	connections := GetSupportedConnectionTypes()
+	g.Expect(connections).To(gomega.HaveLen(2))
+	g.Expect(connections).To(gomega.ContainElement(taxonomy.ConnectionType("s3")))
+	g.Expect(connections).To(gomega.ContainElement(taxonomy.ConnectionType("mysql")))
+}
+
+// test that the correct implemetation has been selected, and the generated object has the correct connection type
+func TestAllocation(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewGomegaWithT(t)
+	conn, err := AllocateStorage(&v1beta2.FybrikStorageAccountSpec{Type: "s3"}, nil, nil)
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(conn.Name).To(gomega.Equal(taxonomy.ConnectionType("s3")))
+}


### PR DESCRIPTION
Signed-off-by: Shlomit Koyfman <shlomitk@il.ibm.com>
This PR closes https://github.com/fybrik/fybrik/issues/1851
Implementation is based on https://github.com/fybrik/fybrik/blob/master/docs/StorageManagement.md#architecture

This PR does not change the existing implementation of storage management in Fybrik because the added storage_manager is not integrated with Fybrik (yet). It demonstrates how the various storage types can be added in order to implement AllocateStorage, DeleteStorage, GetSupportedConnectionTypes functionality of StorageManager by registering placeholder implementations for S3 and MySQL.
Future PRs will replace the placeholder for S3 with actual implementation, define REST APIs, integrate StorageManager with Fybrik, etc.