### PR TITLE
address a problem encountered on an IBM cloud VM (#1862)

### DIFF
--- a/third_party/openmetadata/Makefile.env
+++ b/third_party/openmetadata/Makefile.env
@@ -32,4 +32,4 @@ commit;"
 
 MYSQL_ENDPOINT=mysql.${INSTALLATION_NAMESPACE}.svc.cluster.local
 OPENMETADATA_ENDPOINT=http://openmetadata.${INSTALLATION_NAMESPACE}.svc.cluster.local:8585/api
-AIRFLOW_ENDPOINT=http://openmetadata-dependencies-web.${INSTALLATION_NAMESPACE}.svc.cluster.local:8080
+AIRFLOW_ENDPOINT=http://openmetadata-dependencies-web.${INSTALLATION_NAMESPACE}.svc:8080


### PR DESCRIPTION
For an unknown reason, on the metadata pod,
openmetadata-dependencies-web.open-metadata.svc.cluster.local is unreachable. But if we remove ".cluster.local", the address becomes reachable.
This change was successfully tested on K8S kind and on OpenShift

Signed-off-by: Doron Chen <cdoron@il.ibm.com>