### PR TITLE
bump crdoc to 0.6.2

### DIFF
--- a/hack/make-rules/tools.mk
+++ b/hack/make-rules/tools.mk
@@ -95,7 +95,7 @@ $(TOOLBIN)/oapi-codegen:
 
 INSTALL_TOOLS += $(TOOLBIN)/crdoc
 $(TOOLBIN)/crdoc:
-	GOBIN=$(ABSTOOLBIN) go install fybrik.io/crdoc@v0.6.1
+	GOBIN=$(ABSTOOLBIN) go install fybrik.io/crdoc@v0.6.2
 	$(call post-install-check)
 
 INSTALL_TOOLS += $(TOOLBIN)/json-schema-generator


### PR DESCRIPTION
During the last year there were a lot of updates of third party dependencies of [crdoc](https://github.com/fybrik/crdoc). 
Some of the updates fixed security vulnerabilities. 
Plus, the crdocs repo was promoted to use goLang 1.19.

Here the list of changes at [v0.6.2](https://github.com/fybrik/crdoc/releases/tag/v0.6.2)


Signed-off-by: Alexey Roytman <roytman@il.ibm.com>