### PR TITLE
Fix format selection

### DIFF
--- a/manager/controllers/app/plotter_generator.go
+++ b/manager/controllers/app/plotter_generator.go
@@ -184,10 +184,10 @@ func (p *PlotterGenerator) addStep(element *datapath.ResolvedEdge, datasetID str
 	return steps
 }
 
-// getSupportedFormat returns the first dataformat supported by the module's capability sink interface
-func (p *PlotterGenerator) getSupportedFormat(capability *fappv1.ModuleCapability) taxonomy.DataFormat {
+// getSupportedFormat returns the first dataformat supported by the module's capability sink interface that matches the protocol
+func (p *PlotterGenerator) getSupportedFormat(capability *fappv1.ModuleCapability, protocol taxonomy.ConnectionType) taxonomy.DataFormat {
 	for _, inter := range capability.SupportedInterfaces {
-		if inter.Sink != nil {
+		if inter.Sink != nil && inter.Sink.Protocol == protocol {
 			return inter.Sink.DataFormat
 		}
 	}
@@ -219,7 +219,7 @@ func (p *PlotterGenerator) handleNewAsset(item *datapath.DataInfo, selection *da
 
 	// Fill in the empty dataFormat in the sink node
 	capability := element.Module.Spec.Capabilities[element.CapabilityIndex]
-	element.Sink.Connection.DataFormat = p.getSupportedFormat(&capability)
+	element.Sink.Connection.DataFormat = p.getSupportedFormat(&capability, element.StorageAccount.Type)
 
 	// allocate storage
 	if sinkDataStore, err = p.Provision(item, element.Sink.Connection, &element.StorageAccount); err != nil {


### PR DESCRIPTION
Signed-off-by: Shlomit Koyfman <shlomitk@il.ibm.com>
Related to https://github.com/fybrik/fybrik/issues/1864
For writing a new asset, the format is unknown and is selected from those supported by the module. However, we need to take into account the protocol that is derived from the storage type of the selected storage account.