### PR TITLE
Remove external.json after running 'make generate'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ generate: $(TOOLBIN)/controller-gen $(TOOLBIN)/json-schema-generator
 		-o charts/fybrik/files/taxonomy/taxonomy.json \
 		-b charts/fybrik/files/taxonomy/base_taxonomy.json $(shell find pkg/storage/layers -type f -name '*.yaml')
 	go fix ./...
+	rm -f charts/fybrik/files/taxonomy/external.json
 
 .PHONY: generate-docs
 generate-docs:


### PR DESCRIPTION
After running `make generate`, the `external.json` file is generated by `json-schema-generator` and it contains the types in scanned packages that lack the `+fybrik:validation:object` marker (as stated by the `json-schema-generator` documentation).
The file is not used and not committed, therefore it should be deleted.

Closes #1971 