### PR TITLE
rename leader election ID to prevent conflicts

### DIFF
--- a/charts/fybrik/values.yaml
+++ b/charts/fybrik/values.yaml
@@ -196,7 +196,7 @@ manager:
   discoveryQPS: ""
 
   # Name of leader election ID and the name of the resource lease used for the leader election
-  leaderElectionID: "fybrik-operator-leader-election"
+  leaderElectionID: "fybrik-leader-election"
 
   tls:
     # Relavent if the connection between the manager and one of the connectors


### PR DESCRIPTION
After uninstalling the previous fybrik releases the leader election-related ConfigMap and Lease are left orphans. 

The issue has been fixed for the current release, but if we install this release after a previous one and use the same leader election ID the installation will fail due to existing of a Lease with the same name.
   