### PR TITLE
Fix setting of ADMIN_CRS_NAMESPACE in notebook/write-flow/setup.sh

### DIFF
--- a/manager/testdata/notebook/write-flow/setup.sh
+++ b/manager/testdata/notebook/write-flow/setup.sh
@@ -7,7 +7,9 @@ kubectl create namespace fybrik-notebook-sample
 kubectl config set-context --current --namespace=fybrik-notebook-sample
 
 FYBRIK_NAMESPACE=fybrik-system
-ADMIN_CRS_NAMESPACE?=fybrik-system
+if [[ -z "${ADMIN_CRS_NAMESPACE}" ]]; then
+  ADMIN_CRS_NAMESPACE=fybrik-system
+fi
 
 # Create the storage-accounts
 kubectl -n ${FYBRIK_NAMESPACE} apply -f bucket-creds.yaml -n ${ADMIN_CRS_NAMESPACE}


### PR DESCRIPTION
This PR fixes a current error when running notebook write test:

`./setup.sh: line 10: ADMIN_CRS_NAMESPACE?=fybrik-system: command not found`

https://github.com/fybrik/fybrik/actions/runs/4275568389/jobs/7443019152#step:8:1299