### PR TITLE
Fix notebook read flow and set TEST_VERBOSITY in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ env:
   # the oldest supported K8s version and its respective kind image
   OLD_K8S_VERSION: v1.23.13@sha256:ef453bb7c79f0e3caba88d2067d4196f427794086a7d0df8df4f019d5e336b61
   LATEST_BACKWARD_SUPPORTED_VERSION: 0.7.0
+  TEST_VERBOSITY: 1
 
 jobs:
   verify:

--- a/manager/testdata/notebook/read-flow/setup.sh
+++ b/manager/testdata/notebook/read-flow/setup.sh
@@ -18,20 +18,21 @@ else
   port=8080
   local_port=8081
   prefix=http
-  kubectl get secret test-tls-localhost-certs -n fybrik-system -o json | jq -r '.data."tls.key"' | base64 -d > tls.key
-  kubectl get secret test-tls-localhost-certs -n fybrik-system -o json | jq -r '.data."tls.crt"' | base64 -d > tls.crt
 
   if [[ "${DEPLOY_TLS_TEST_CERTS}" -eq 1 ]]; then
     port=8443
     prefix=https
     local_port=8443
+    kubectl get secret test-tls-localhost-certs -n fybrik-system -o json | jq -r '.data."tls.key"' | base64 -d > tls.key
+    kubectl get secret test-tls-localhost-certs -n fybrik-system -o json | jq -r '.data."tls.crt"' | base64 -d > tls.crt
+    certs=" --cert tls.crt --key tls.key "
   fi
   # Deploy openmetadata asset
   kubectl port-forward svc/openmetadata-connector -n fybrik-system $local_port:$port &
   # Wait until curl command succeed
   c=0
   # -k flag is used to skip server verification to avoid errors regarding target host name 'localhost'
-  while [[ $(curl --cert tls.crt --key tls.key -k -X POST $prefix://localhost:$local_port/createAsset -d @om-asset.json) != *'assetID'* ]]
+  while [[ $(curl $certs -k -X POST $prefix://localhost:$local_port/createAsset -d @om-asset.json) != *'assetID'* ]]
   do
     echo "waiting for curl command to createAsset to succeed"
     ((c++)) && ((c==25)) && break


### PR DESCRIPTION
This PR fixes notebook read flow which is currently looking at `test-tls-localhost-certs` secret even if the test is not running with TLS.
It also sets TEST_VERBOSITY in build.yml workflow