### PR TITLE
Support all connection types from a specific catalog provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,7 @@ test: export MODULES_NAMESPACE?=fybrik-blueprints
 test: export CONTROLLER_NAMESPACE?=fybrik-system
 test: export ADMIN_CRS_NAMESPACE?=fybrik-admin
 test: export INTERNAL_CRS_NAMESPACE?=fybrik-crd
+tests: export CATALOG_PROVIDER_NAME=mockup-catalog
 test: export CSP_PATH=$(ABSTOOLBIN)/solver
 test: export CSP_ARGS=--logtostderr
 test: pre-test

--- a/manager/controllers/app/fybrikapplication_controller.go
+++ b/manager/controllers/app/fybrikapplication_controller.go
@@ -13,6 +13,7 @@ import (
 
 	"emperror.dev/errors"
 	"github.com/rs/zerolog"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -798,9 +799,38 @@ func (r *FybrikApplicationReconciler) GetAllModules() (map[string]*fappv1.Fybrik
 		return moduleMap, err
 	}
 	for ind := range moduleList.Items {
+		if !validateModule(&moduleList.Items[ind]) {
+			continue
+		}
 		moduleMap[moduleList.Items[ind].Name] = &moduleList.Items[ind]
 	}
 	return moduleMap, nil
+}
+
+// validate that the module can be selected:
+// 1. check the module validation status
+// 2. special processing for modules that support any connections from a specific catalog provider -
+// set the protocol value to an empty one (empty values stand for "*" and are not checked)
+func validateModule(module *fappv1.FybrikModule) bool {
+	if len(module.Status.Conditions) > 0 &&
+		module.Status.Conditions[ModuleValidationConditionIndex].Status == corev1.ConditionFalse {
+		return false
+	}
+	for capabilityInd := range module.Spec.Capabilities {
+		for interfaceInd := range module.Spec.Capabilities[capabilityInd].SupportedInterfaces {
+			if module.Spec.Capabilities[capabilityInd].SupportedInterfaces[interfaceInd].Source != nil &&
+				module.Spec.Capabilities[capabilityInd].SupportedInterfaces[interfaceInd].Source.Protocol ==
+					taxonomy.ConnectionType(environment.GetCatalogProvider()) {
+				module.Spec.Capabilities[capabilityInd].SupportedInterfaces[interfaceInd].Source.Protocol = ""
+			}
+			if module.Spec.Capabilities[capabilityInd].SupportedInterfaces[interfaceInd].Sink != nil &&
+				module.Spec.Capabilities[capabilityInd].SupportedInterfaces[interfaceInd].Sink.Protocol ==
+					taxonomy.ConnectionType(environment.GetCatalogProvider()) {
+				module.Spec.Capabilities[capabilityInd].SupportedInterfaces[interfaceInd].Sink.Protocol = ""
+			}
+		}
+	}
+	return true
 }
 
 // get all available storage accounts

--- a/manager/controllers/app/fybrikapplication_controller.go
+++ b/manager/controllers/app/fybrikapplication_controller.go
@@ -815,16 +815,17 @@ func validateModule(module *fappv1.FybrikModule) bool {
 		module.Status.Conditions[ModuleValidationConditionIndex].Status == v1.ConditionFalse {
 		return false
 	}
+	catalogProviderName := environment.GetCatalogProvider()
 	for capabilityInd := range module.Spec.Capabilities {
 		for interfaceInd := range module.Spec.Capabilities[capabilityInd].SupportedInterfaces {
-			if module.Spec.Capabilities[capabilityInd].SupportedInterfaces[interfaceInd].Source != nil &&
-				module.Spec.Capabilities[capabilityInd].SupportedInterfaces[interfaceInd].Source.Protocol ==
-					taxonomy.ConnectionType(environment.GetCatalogProvider()) {
+			if module.Spec.Capabilities[capabilityInd].SupportedInterfaces[interfaceInd].Source != nil && strings.EqualFold(
+				string(module.Spec.Capabilities[capabilityInd].SupportedInterfaces[interfaceInd].Source.Protocol),
+				catalogProviderName) {
 				module.Spec.Capabilities[capabilityInd].SupportedInterfaces[interfaceInd].Source.Protocol = ""
 			}
-			if module.Spec.Capabilities[capabilityInd].SupportedInterfaces[interfaceInd].Sink != nil &&
-				module.Spec.Capabilities[capabilityInd].SupportedInterfaces[interfaceInd].Sink.Protocol ==
-					taxonomy.ConnectionType(environment.GetCatalogProvider()) {
+			if module.Spec.Capabilities[capabilityInd].SupportedInterfaces[interfaceInd].Sink != nil && strings.EqualFold(
+				string(module.Spec.Capabilities[capabilityInd].SupportedInterfaces[interfaceInd].Sink.Protocol),
+				catalogProviderName) {
 				module.Spec.Capabilities[capabilityInd].SupportedInterfaces[interfaceInd].Sink.Protocol = ""
 			}
 		}

--- a/manager/controllers/app/fybrikapplication_controller.go
+++ b/manager/controllers/app/fybrikapplication_controller.go
@@ -798,23 +798,21 @@ func (r *FybrikApplicationReconciler) GetAllModules() (map[string]*fappv1.Fybrik
 		return moduleMap, err
 	}
 	for ind := range moduleList.Items {
-		if !validateModule(&moduleList.Items[ind]) {
+		module := &moduleList.Items[ind]
+		if len(module.Status.Conditions) > 0 &&
+			module.Status.Conditions[ModuleValidationConditionIndex].Status == v1.ConditionFalse {
+			r.Log.Warn().Msgf("ignoring invalid module %s", module.Name)
 			continue
 		}
+		refineCapabilities(module)
 		moduleMap[moduleList.Items[ind].Name] = &moduleList.Items[ind]
 	}
 	return moduleMap, nil
 }
 
-// validate that the module can be selected:
-// 1. check the module validation status
-// 2. special processing for modules that support any connections from a specific catalog provider -
+// special processing for modules that support any connections from a specific catalog provider -
 // set the protocol value to an empty one (empty values stand for "*" and are not checked)
-func validateModule(module *fappv1.FybrikModule) bool {
-	if len(module.Status.Conditions) > 0 &&
-		module.Status.Conditions[ModuleValidationConditionIndex].Status == v1.ConditionFalse {
-		return false
-	}
+func refineCapabilities(module *fappv1.FybrikModule) {
 	catalogProviderName := environment.GetCatalogProvider()
 	for capabilityInd := range module.Spec.Capabilities {
 		for interfaceInd := range module.Spec.Capabilities[capabilityInd].SupportedInterfaces {
@@ -830,7 +828,6 @@ func validateModule(module *fappv1.FybrikModule) bool {
 			}
 		}
 	}
-	return true
 }
 
 // get all available storage accounts

--- a/manager/controllers/app/fybrikapplication_controller.go
+++ b/manager/controllers/app/fybrikapplication_controller.go
@@ -13,7 +13,6 @@ import (
 
 	"emperror.dev/errors"
 	"github.com/rs/zerolog"
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -813,7 +812,7 @@ func (r *FybrikApplicationReconciler) GetAllModules() (map[string]*fappv1.Fybrik
 // set the protocol value to an empty one (empty values stand for "*" and are not checked)
 func validateModule(module *fappv1.FybrikModule) bool {
 	if len(module.Status.Conditions) > 0 &&
-		module.Status.Conditions[ModuleValidationConditionIndex].Status == corev1.ConditionFalse {
+		module.Status.Conditions[ModuleValidationConditionIndex].Status == v1.ConditionFalse {
 		return false
 	}
 	for capabilityInd := range module.Spec.Capabilities {

--- a/manager/controllers/app/suite_test.go
+++ b/manager/controllers/app/suite_test.go
@@ -208,6 +208,7 @@ func SetIfNotSet(key, value string, t GinkgoTInterface) {
 
 func DefaultTestConfiguration(t GinkgoTInterface) {
 	SetIfNotSet(environment.CatalogConnectorServiceAddressKey, "http://localhost:50085", t)
+	SetIfNotSet(environment.CatalogProviderNameKey, "mockup-catalog", t)
 	SetIfNotSet(environment.VaultAddressKey, "http://127.0.0.1:8200/", t)
 	SetIfNotSet(environment.EnableWebhooksKey, "false", t)
 	SetIfNotSet(environment.MainPolicyManagerConnectorURLKey, "http://localhost:50090", t)

--- a/manager/testdata/unittests/module-read-any.yaml
+++ b/manager/testdata/unittests/module-read-any.yaml
@@ -1,0 +1,27 @@
+# Copyright 2020 IBM Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: app.fybrik.io/v1beta1
+kind: FybrikModule
+metadata:
+  name: arrow-flight-module
+  labels:
+    name: arrow-flight-module
+    version: 0.0.1  # semantic version
+spec:
+  chart:
+    name:  ghcr.io/fybrik/fybrik-template:0.1.0
+  type: service
+  capabilities:
+    - capability: read
+      scope: workload
+      api:
+        connection:
+          name: fybrik-arrow-flight
+          fybrik-arrow-flight:
+            hostname: read-path.{{ .Release.Name}}.{{ get .Values.labels "app" | default .Release.Namespace }}
+            port: 80
+            scheme: grpc
+      supportedInterfaces:
+      - source:
+          protocol: mockup-catalog

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -77,6 +77,10 @@ func GetLocalVaultAuthPath() string {
 	return os.Getenv(LocalVaultAuthPath)
 }
 
+func GetCatalogProvider() string {
+	return os.Getenv(CatalogProviderNameKey)
+}
+
 func GetDefaultModulesNamespace() string {
 	ns := os.Getenv(ModuleNamespace)
 	if ns == "" {


### PR DESCRIPTION
Closes https://github.com/fybrik/fybrik/issues/2030
This PR enables a module to list all connections supported by a specific catalog provider by specifying the catalog provider name in the `protocol` field of FybrikModule yaml.