### PR TITLE
Removing go-toolset

### DIFF
--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -2,9 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 ARG tag=8.7
 FROM registry.access.redhat.com/ubi8/ubi-minimal:$tag
-# this is required for FIPS support
-RUN microdnf -y update && microdnf clean all
-RUN microdnf install -y go-toolset
 ENV HOME=/tmp
 WORKDIR $HOME
 COPY manager /


### PR DESCRIPTION
Removing go-toolset as it comes with Various vulnerabilities and maintenance becomes difficult.  We will set GOLANG_FIPS=1 instead.