### PR TITLE
Add kind with calico installation instruction

### DIFF
--- a/docs/IsolationNetworkPolicies.md
+++ b/docs/IsolationNetworkPolicies.md
@@ -26,7 +26,7 @@ complicates the configuration. Therefore, later we will provide other isolation 
 - NP are implemented by the network plugin. Creating a NetworkPolicy resource without a controller - a Container Network 
 Interface (CNI) that implements it will have no effect. For example, `Kind` deployments which by default use "kindnetd" 
 do not support NP. In order to support NP, installation of another CNI, e.g. [Calico](https://github.com/projectcalico/calico)
-is required. Below there are instruction how to install kind with calico networking.  [instructions](https://alexbrand.dev/post/creating-a-kind-cluster-with-calico-networking/). 
+is required. Below there are instruction how to install kind with calico networking. 
 On the other hand, all K8s clusters in production deployments use CNIs which support NP.
 
 <details> 

--- a/docs/IsolationNetworkPolicies.md
+++ b/docs/IsolationNetworkPolicies.md
@@ -125,12 +125,12 @@ The `Selector` will have the following structure:
 ```go
 type Selector struct {
 	// Cluster name 
-	//+optional 
+	// +optional 
 	ClusterName string `json:"clusterName"`
 	
-	WorkloadSelector enables to connect the resource to the application 
+	// WorkloadSelector enables to connect the resource to the application 
 	// Applications labels should match the labels in the selector. 
-	//+required 
+	// +required 
 	WorkloadSelector metav1.LabelSelector `json:"workloadSelector"`
 	
 	// Namespaces where user application might run

--- a/manager/testdata/kind-calico.yaml
+++ b/manager/testdata/kind-calico.yaml
@@ -1,0 +1,5 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  disableDefaultCNI: true # disable kindnet
+  podSubnet: 192.168.0.0/16 # set to Calico's default subnet


### PR DESCRIPTION
The [Creating a Kind Cluster With Calico Networking](https://alexbrand.dev/post/creating-a-kind-cluster-with-calico-networking/) is not up to date, so this PR adds instructions into the design document. 
Later they can be propagated to the Web site.