### PR TITLE
Call port-forwarding of the module inside a loop in the notebook tests.

### DIFF
--- a/manager/controllers/app/fybrik_notebook_read_flow_test.go
+++ b/manager/controllers/app/fybrik_notebook_read_flow_test.go
@@ -40,11 +40,11 @@ import (
 )
 
 const (
-	readFlow                           string        = "charts/fybrik/notebook-test-readflow.values.yaml"
-	readFlowTLS                        string        = "charts/fybrik/notebook-test-readflow.tls.values.yaml"
-	readFlowTLSCA                      string        = "charts/fybrik/notebook-test-readflow.tls-system-cacerts.yaml"
-	PortFowardingMaxRetryAttempts      int           = 25
-	PortFowardingWaitInSecUntilNextTry time.Duration = 5
+	readFlow                      string        = "charts/fybrik/notebook-test-readflow.values.yaml"
+	readFlowTLS                   string        = "charts/fybrik/notebook-test-readflow.tls.values.yaml"
+	readFlowTLSCA                 string        = "charts/fybrik/notebook-test-readflow.tls-system-cacerts.yaml"
+	PortFowardingMaxRetryAttempts int           = 25
+	PortForwardingDelay           time.Duration = 5
 )
 
 type ArrowRequest struct {
@@ -70,7 +70,7 @@ func RunPortForwardCommandWithRetryAttemps(modulesNamespace, svcName string, por
 			return "", errors.New("failed to terminate port-forward " + err.Error())
 		}
 
-		time.Sleep(PortFowardingWaitInSecUntilNextTry * time.Second)
+		time.Sleep(PortForwardingDelay * time.Second)
 		i++
 	}
 	return "", errors.New("Port Forwarding command failed with error")

--- a/manager/controllers/app/fybrik_notebook_read_flow_test.go
+++ b/manager/controllers/app/fybrik_notebook_read_flow_test.go
@@ -40,10 +40,11 @@ import (
 )
 
 const (
-	readFlow                      string = "charts/fybrik/notebook-test-readflow.values.yaml"
-	readFlowTLS                   string = "charts/fybrik/notebook-test-readflow.tls.values.yaml"
-	readFlowTLSCA                 string = "charts/fybrik/notebook-test-readflow.tls-system-cacerts.yaml"
-	PortFowardingMaxRetryAttempts int    = 25
+	readFlow                           string        = "charts/fybrik/notebook-test-readflow.values.yaml"
+	readFlowTLS                        string        = "charts/fybrik/notebook-test-readflow.tls.values.yaml"
+	readFlowTLSCA                      string        = "charts/fybrik/notebook-test-readflow.tls-system-cacerts.yaml"
+	PortFowardingMaxRetryAttempts      int           = 25
+	PortFowardingWaitInSecUntilNextTry time.Duration = 10
 )
 
 type ArrowRequest struct {
@@ -69,7 +70,7 @@ func RunPortForwardCommandWithRetryAttemps(modulesNamespace, svcName string, por
 			return "", errors.New("failed to terminate port-forward " + err.Error())
 		}
 
-		time.Sleep(10 * time.Second)
+		time.Sleep(PortFowardingWaitInSecUntilNextTry * time.Second)
 		i++
 	}
 	return "", errors.New("Port Forwarding command failed with error")

--- a/manager/controllers/app/fybrik_notebook_read_flow_test.go
+++ b/manager/controllers/app/fybrik_notebook_read_flow_test.go
@@ -66,7 +66,7 @@ func RunPortForwardCommandWithRetryAttemps(modulesNamespace, svcName string, por
 
 		err = test.StopPortForward(cmd)
 		if err != nil {
-			return "", errors.New("Port Forwarding command failed with error" + err.Error())
+			return "", errors.New("failed to terminate port-forward " + err.Error())
 		}
 
 		time.Sleep(10 * time.Second)
@@ -310,7 +310,7 @@ func TestS3NotebookReadFlow(t *testing.T) {
 	if err != nil {
 		g.Fail("Port Forwarding command failed with error " + err.Error())
 	}
-	fmt.Printf("kubectl port-forward succeded")
+	fmt.Printf("kubectl port-forward succeeded")
 
 	// Reading data via arrow flight
 	opts := make([]grpc.DialOption, 0)

--- a/manager/controllers/app/fybrik_notebook_read_flow_test.go
+++ b/manager/controllers/app/fybrik_notebook_read_flow_test.go
@@ -44,7 +44,7 @@ const (
 	readFlowTLS                        string        = "charts/fybrik/notebook-test-readflow.tls.values.yaml"
 	readFlowTLSCA                      string        = "charts/fybrik/notebook-test-readflow.tls-system-cacerts.yaml"
 	PortFowardingMaxRetryAttempts      int           = 25
-	PortFowardingWaitInSecUntilNextTry time.Duration = 10
+	PortFowardingWaitInSecUntilNextTry time.Duration = 5
 )
 
 type ArrowRequest struct {
@@ -303,7 +303,7 @@ func TestS3NotebookReadFlow(t *testing.T) {
 	port := fmt.Sprintf("%v", connection["port"])
 	svcName := strings.Replace(hostname, "."+modulesNamespace, "", 1)
 
-	fmt.Printf("Starting kubectl port-forward for arrow-flight service %s port %s in ns %s", svcName, port, modulesNamespace)
+	fmt.Printf("Starting kubectl port-forward for arrow-flight service %s port %s in ns %s\n", svcName, port, modulesNamespace)
 	portNum, err := strconv.Atoi(port)
 	g.Expect(err).To(gomega.BeNil(), "wrong port number %s", port)
 
@@ -311,7 +311,7 @@ func TestS3NotebookReadFlow(t *testing.T) {
 	if err != nil {
 		g.Fail("Port Forwarding command failed with error " + err.Error())
 	}
-	fmt.Printf("kubectl port-forward succeeded")
+	fmt.Println("kubectl port-forward succeeded")
 
 	// Reading data via arrow flight
 	opts := make([]grpc.DialOption, 0)
@@ -360,4 +360,5 @@ func TestS3NotebookReadFlow(t *testing.T) {
 		}
 	}
 	record.Release()
+	fmt.Println("read-flow test succeeded")
 }

--- a/manager/controllers/app/fybrik_notebook_write_flow_test.go
+++ b/manager/controllers/app/fybrik_notebook_write_flow_test.go
@@ -397,7 +397,7 @@ func TestS3NotebookWriteFlow(t *testing.T) {
 	if err != nil {
 		g.Fail("Port Forwarding command failed with error " + err.Error())
 	}
-	fmt.Printf("kubectl port-forward command succeeded")
+	fmt.Println("kubectl port-forward command succeeded")
 
 	// Reading data via arrow flight
 	opts = make([]grpc.DialOption, 0)
@@ -454,4 +454,5 @@ func TestS3NotebookWriteFlow(t *testing.T) {
 	g.Eventually(func() error {
 		return k8sClient.Delete(context.Background(), readApplication)
 	}, timeout, interval).Should(gomega.Succeed())
+	fmt.Println("write-flow test succeeded")
 }

--- a/manager/controllers/app/fybrik_notebook_write_flow_test.go
+++ b/manager/controllers/app/fybrik_notebook_write_flow_test.go
@@ -31,7 +31,6 @@ import (
 
 	fappv1 "fybrik.io/fybrik/manager/apis/app/v1beta1"
 	fappv2 "fybrik.io/fybrik/manager/apis/app/v1beta2"
-	"fybrik.io/fybrik/pkg/test"
 )
 
 const (
@@ -44,7 +43,7 @@ func TestS3NotebookWriteFlow(t *testing.T) {
 	}
 	gomega.RegisterFailHandler(Fail)
 
-	g := gomega.NewGomegaWithT(t)
+	g := gomega.NewWithT(t)
 	defer GinkgoRecover()
 
 	err := fappv1.AddToScheme(scheme.Scheme)
@@ -244,8 +243,11 @@ func TestS3NotebookWriteFlow(t *testing.T) {
 	fmt.Println("Starting kubectl port-forward for arrow-flight")
 	portNum, err := strconv.Atoi(port)
 	g.Expect(err).To(gomega.BeNil())
-	listenPort, err := test.RunPortForward(modulesNamespace, svcName, portNum)
-	g.Expect(err).To(gomega.BeNil())
+
+	listenPort, err := RunPortForwardCommandWithRetryAttemps(modulesNamespace, svcName, portNum)
+	if err != nil {
+		g.Fail("Port Forwarding command failed with error " + err.Error())
+	}
 
 	// Writing data via arrow flight
 	opts := make([]grpc.DialOption, 0)
@@ -391,8 +393,11 @@ func TestS3NotebookWriteFlow(t *testing.T) {
 	fmt.Println("Starting kubectl port-forward for arrow-flight")
 	portNum, err = strconv.Atoi(port)
 	g.Expect(err).To(gomega.BeNil())
-	listenPort, err = test.RunPortForward(modulesNamespace, svcName, portNum)
-	g.Expect(err).To(gomega.BeNil())
+
+	listenPort, err = RunPortForwardCommandWithRetryAttemps(modulesNamespace, svcName, portNum)
+	if err != nil {
+		g.Fail("Port Forwarding command failed with error " + err.Error())
+	}
 
 	// Reading data via arrow flight
 	opts = make([]grpc.DialOption, 0)

--- a/manager/controllers/app/fybrik_notebook_write_flow_test.go
+++ b/manager/controllers/app/fybrik_notebook_write_flow_test.go
@@ -43,7 +43,7 @@ func TestS3NotebookWriteFlow(t *testing.T) {
 	}
 	gomega.RegisterFailHandler(Fail)
 
-	g := gomega.NewWithT(t)
+	g := gomega.NewGomegaWithT(t)
 	defer GinkgoRecover()
 
 	err := fappv1.AddToScheme(scheme.Scheme)
@@ -243,11 +243,11 @@ func TestS3NotebookWriteFlow(t *testing.T) {
 	fmt.Println("Starting kubectl port-forward for arrow-flight")
 	portNum, err := strconv.Atoi(port)
 	g.Expect(err).To(gomega.BeNil())
-
 	listenPort, err := RunPortForwardCommandWithRetryAttemps(modulesNamespace, svcName, portNum)
 	if err != nil {
 		g.Fail("Port Forwarding command failed with error " + err.Error())
 	}
+	fmt.Printf("kubectl port-forward command succeded")
 
 	// Writing data via arrow flight
 	opts := make([]grpc.DialOption, 0)
@@ -393,11 +393,11 @@ func TestS3NotebookWriteFlow(t *testing.T) {
 	fmt.Println("Starting kubectl port-forward for arrow-flight")
 	portNum, err = strconv.Atoi(port)
 	g.Expect(err).To(gomega.BeNil())
-
 	listenPort, err = RunPortForwardCommandWithRetryAttemps(modulesNamespace, svcName, portNum)
 	if err != nil {
 		g.Fail("Port Forwarding command failed with error " + err.Error())
 	}
+	fmt.Printf("kubectl port-forward command succeded")
 
 	// Reading data via arrow flight
 	opts = make([]grpc.DialOption, 0)

--- a/manager/controllers/app/fybrik_notebook_write_flow_test.go
+++ b/manager/controllers/app/fybrik_notebook_write_flow_test.go
@@ -43,7 +43,7 @@ func TestS3NotebookWriteFlow(t *testing.T) {
 	}
 	gomega.RegisterFailHandler(Fail)
 
-	g := gomega.NewGomegaWithT(t)
+	g := gomega.NewWithT(t)
 	defer GinkgoRecover()
 
 	err := fappv1.AddToScheme(scheme.Scheme)
@@ -247,7 +247,7 @@ func TestS3NotebookWriteFlow(t *testing.T) {
 	if err != nil {
 		g.Fail("Port Forwarding command failed with error " + err.Error())
 	}
-	fmt.Printf("kubectl port-forward command succeded")
+	fmt.Printf("kubectl port-forward command succeeded")
 
 	// Writing data via arrow flight
 	opts := make([]grpc.DialOption, 0)
@@ -397,7 +397,7 @@ func TestS3NotebookWriteFlow(t *testing.T) {
 	if err != nil {
 		g.Fail("Port Forwarding command failed with error " + err.Error())
 	}
-	fmt.Printf("kubectl port-forward command succeded")
+	fmt.Printf("kubectl port-forward command succeeded")
 
 	// Reading data via arrow flight
 	opts = make([]grpc.DialOption, 0)

--- a/pkg/test/portforward.go
+++ b/pkg/test/portforward.go
@@ -66,7 +66,7 @@ func RunPortForward(ns, svcName string, port int) (string, *exec.Cmd, error) {
 
 	_, err = strconv.Atoi(match[2])
 	if err != nil {
-		return "", nil, err
+		return "", cmd, err
 	}
 
 	return match[2], cmd, nil

--- a/pkg/test/portforward.go
+++ b/pkg/test/portforward.go
@@ -4,10 +4,12 @@
 package test
 
 import (
+	"errors"
 	"io"
 	"os/exec"
 	"regexp"
 	"strconv"
+	"syscall"
 )
 
 const (
@@ -40,7 +42,7 @@ func StartCmdAndStreamOutput(cmd *exec.Cmd) (stdout, stderr io.ReadCloser, err e
 
 // runPortForward runs port-forward, warning, this may need root functionality on some systems.
 // The function was inspired from kubernetes e2e framework
-func RunPortForward(ns, svcName string, port int) (string, error) {
+func RunPortForward(ns, svcName string, port int) (string, *exec.Cmd, error) {
 	// #nosec G204 -- Avoid "Subprocess launched with variable" error
 	cmd := exec.Command("kubectl", "-n", ns, "port-forward", "svc/"+svcName, ":"+strconv.Itoa(port))
 	// This is somewhat ugly but is the only way to retrieve the port that was picked
@@ -48,24 +50,34 @@ func RunPortForward(ns, svcName string, port int) (string, error) {
 	// way of guaranteeing we can pick one that isn't in use, particularly on Jenkins.
 	portOutput, _, err := StartCmdAndStreamOutput(cmd)
 	if err != nil {
-		return "", err
+		return "", cmd, err
 	}
 
 	buf := make([]byte, bufferInitalSize)
 	var n int
 	if n, err = portOutput.Read(buf); err != nil {
-		return "", err
+		return "", cmd, err
 	}
 	portForwardOutput := string(buf[:n])
 	match := portForwardRegexp.FindStringSubmatch(portForwardOutput)
 	if len(match) != regexpPortMatchLen {
-		return "", err
+		return "", cmd, err
 	}
 
 	_, err = strconv.Atoi(match[2])
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 
-	return match[2], nil
+	return match[2], cmd, nil
+}
+
+// This function stops PortForward command
+func StopPortForward(cmd *exec.Cmd) error {
+	// SIGINT signals that kubectl port-forward should gracefully terminate
+	if err := cmd.Process.Signal(syscall.SIGINT); err != nil {
+		return errors.New("error sending SIGINT to kubectl port-forward: " + err.Error())
+	}
+
+	return nil
 }


### PR DESCRIPTION
This PR tries to solve the scenario that @shlomitk1 raised in #1860 where the port forwarding of the module service fails as its pod is not ready.