### PR TITLE
Add missing flag to opa deployment and update notebook read-flow test…

### DIFF
--- a/charts/fybrik/notebook-test-readflow.tls-system-cacerts.yaml
+++ b/charts/fybrik/notebook-test-readflow.tls-system-cacerts.yaml
@@ -78,26 +78,6 @@ opaConnector:
   service:
     port: 8443
 
-opaServer:
-  # Bootstrap policies to load upon startup
-  bootstrapPolicies:
-    notebookSamplePolicy: |-
-      package dataapi.authz
-
-      rule[{}] {
-        description := "allow read datasets with no tags"
-        input.action.actionType == "read"
-        not input.resource.metadata.tags
-      }
-
-      rule[{"action": {"name":"RedactAction", "columns": column_names}, "policy": description}] {
-        description := "While reading redact columns tagged as PII in datasets tagged with finance = true"
-        input.action.actionType == "read"
-        input.resource.metadata.tags.finance
-        column_names := [input.resource.metadata.columns[i].name | input.resource.metadata.columns[i].tags.PII]
-      }
-
-
 # S3 mock service installed in fybrik namespace
 s3mock:
   enabled: true

--- a/charts/fybrik/notebook-test-readflow.tls.values.yaml
+++ b/charts/fybrik/notebook-test-readflow.tls.values.yaml
@@ -88,25 +88,6 @@ opaServer:
   service:
     port: 8443
 
-  # Bootstrap policies to load upon startup
-  bootstrapPolicies:
-    notebookSamplePolicy: |-
-      package dataapi.authz
-
-      rule[{}] {
-        description := "allow read datasets with no tags"
-        input.action.actionType == "read"
-        not input.resource.metadata.tags
-      }
-
-      rule[{"action": {"name":"RedactAction", "columns": column_names}, "policy": description}] {
-        description := "While reading redact columns tagged as PII in datasets tagged with finance = true"
-        input.action.actionType == "read"
-        input.resource.metadata.tags.finance
-        column_names := [input.resource.metadata.columns[i].name | input.resource.metadata.columns[i].tags.PII]
-      }
-
-
 # S3 mock service installed in fybrik namespace
 s3mock:
   enabled: true

--- a/charts/fybrik/templates/opa-server/opa-deployment.yaml
+++ b/charts/fybrik/templates/opa-server/opa-deployment.yaml
@@ -147,6 +147,8 @@ spec:
           {{- if .Values.opaServer.tls.use_tls }}
           - --opa-url=https://127.0.0.1:{{ .Values.opaServer.service.port }}/v1
           {{- end }}
+          # taken from https://github.com/open-policy-agent/kube-mgmt/blob/8.1.0/charts/opa-kube-mgmt/templates/deployment.yaml#L184
+          - --opa-allow-insecure
           - --require-policy-label
           - --policies={{ .Release.Namespace }}
           - --enable-data


### PR DESCRIPTION
…s with tls.

This PR adds missiing flag to kube-mgmt container in opa deployment as is done in https://github.com/open-policy-agent/kube-mgmt/blob/8.1.0/charts/opa-kube-mgmt/templates/deployment.yaml#L184 and also updates the notebook read-flow tests with tls to avoid using boostrap policies.