### PR TITLE
Comment out depricated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -68,13 +68,11 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - dogsled
     - dupl
     - errcheck
     - exportloopref
     - funlen
-    # - gochecknoinits
     - goconst
     - gocritic
     - gocyclo
@@ -91,17 +89,19 @@ linters:
     - noctx
     - nolintlint
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
     - whitespace
     - revive
 
   # don't enable:
+  # - gochecknoinits
+  # - deadcode
+  # - structcheck
+  # - varcheck
   # - asciicheck
   # - depguard
   # - scopelint


### PR DESCRIPTION
Prevents the following warnings:

```
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused.
WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused.
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused.
WARN [linters_context] structcheck is disabled because of generics. You can track the evolution of the generics support by following the https://github.com/golangci/golangci-lint/issues/2649.
```