### PR TITLE
Replace reflect.DeepEqual by equality.Semantic.DeepEqual

### DIFF
--- a/manager/controllers/app/plotter_controller.go
+++ b/manager/controllers/app/plotter_controller.go
@@ -7,12 +7,12 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"reflect"
 	"strings"
 	"time"
 
 	"emperror.dev/errors"
 	"github.com/rs/zerolog"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -348,7 +348,7 @@ func (r *PlotterReconciler) reconcile(plotter *fapp.Plotter) (ctrl.Result, []err
 
 			logging.LogStructure("Remote blueprint", remoteBlueprint, &log, zerolog.DebugLevel, false, true)
 
-			if !reflect.DeepEqual(&blueprintSpec, &remoteBlueprint.Spec) {
+			if !equality.Semantic.DeepEqual(&blueprintSpec, &remoteBlueprint.Spec) {
 				r.Log.Warn().Msg("Blueprint specs differ.  plotter.generation " + fmt.Sprint(plotter.Generation) +
 					" plotter.observedGeneration " + fmt.Sprint(plotter.Status.ObservedGeneration))
 				if plotter.Generation != plotter.Status.ObservedGeneration {


### PR DESCRIPTION
Sometimes reflect.DeepEqual returned false when comparing two equal structures (blueprint specs). As a result, a ready status was not propagated into the plotter status, and application was not becoming ready.
Fixes https://github.com/fybrik/fybrik/issues/1860