### PR TITLE
Improved the error message when no modules are deployed

### DIFF
--- a/manager/controllers/app/fybrikapplication_controller.go
+++ b/manager/controllers/app/fybrikapplication_controller.go
@@ -89,6 +89,7 @@ const (
 	ModuleNotFound              string = "no module has been registered"
 	InsufficientStorage         string = "no bucket was provisioned for implicit copy"
 	InvalidClusterConfiguration string = "cluster configuration does not support the requirements"
+	NoDeployedModules           string = "There are no deployed modules in the environment"
 )
 
 // Reconcile reconciles FybrikApplication CRD

--- a/manager/controllers/app/solve.go
+++ b/manager/controllers/app/solve.go
@@ -45,10 +45,8 @@ func solveSingleDataset(env *datapath.Environment, dataset *datapath.DataInfo, l
 // find a solution for all data paths at once
 func solve(env *datapath.Environment, datasets []datapath.DataInfo, log *zerolog.Logger) ([]datapath.Solution, error) {
 	solutions := []datapath.Solution{}
-	if len(env.Modules) == 0 {
-		msg := "There are no deployed modules in the environment"
-		log.Error().Msg(msg)
-		return solutions, errors.New(msg)
+	if err := validateBasicConditions(env, log); err != nil {
+		return solutions, err
 	}
 	for i := range datasets {
 		solution, err := solveSingleDataset(env, &datasets[i], log)
@@ -58,4 +56,13 @@ func solve(env *datapath.Environment, datasets []datapath.DataInfo, log *zerolog
 		solutions = append(solutions, solution)
 	}
 	return solutions, nil
+}
+
+// perform basic checks before searching for a solution for a dataset
+func validateBasicConditions(env *datapath.Environment, log *zerolog.Logger) error {
+	if len(env.Modules) == 0 {
+		log.Error().Msg(NoDeployedModules)
+		return errors.New(NoDeployedModules)
+	}
+	return nil
 }

--- a/manager/controllers/app/solve.go
+++ b/manager/controllers/app/solve.go
@@ -45,6 +45,11 @@ func solveSingleDataset(env *datapath.Environment, dataset *datapath.DataInfo, l
 // find a solution for all data paths at once
 func solve(env *datapath.Environment, datasets []datapath.DataInfo, log *zerolog.Logger) ([]datapath.Solution, error) {
 	solutions := []datapath.Solution{}
+	if len(env.Modules) == 0 {
+		msg := "There are no deployed modules in the environment"
+		log.Error().Msg(msg)
+		return solutions, errors.New(msg)
+	}
 	for i := range datasets {
 		solution, err := solveSingleDataset(env, &datasets[i], log)
 		if err != nil {

--- a/manager/controllers/app/solve_test.go
+++ b/manager/controllers/app/solve_test.go
@@ -193,13 +193,15 @@ func createDeleteRequest() *datapath.DataInfo {
 	}
 }
 
-// no clusters/modules - data path can't be constructed
+// no clusters/modules - no deployed modules in the environment
 func TestEmptyEnvironment(t *testing.T) {
 	t.Parallel()
 	g := gomega.NewGomegaWithT(t)
 	env := newEnvironment()
-	_, err := solveSingleDataset(env, createReadRequest(), &testLog)
+	asset := createReadRequest()
+	_, err := solve(env, []datapath.DataInfo{*asset}, &testLog)
 	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(err.Error()).To(gomega.BeIdenticalTo(NoDeployedModules))
 }
 
 // transformations are required but not supported by the read module


### PR DESCRIPTION
Closes #2054 

Added a check if any modules are deployed before attempting to find data path solutions. If not, a relevant message is logged and appears in the status of the `fybrikapplication`.

I verified in a local `kind` cluster that the new message appears in the `fybrikapplication` status and in the logs when no modules are deployed, and that once the right module is deployed the `fybrikapplication` is ready.





