### PR TITLE
Improve logs collector script 

### DIFF
--- a/hack/save-logs-files.sh
+++ b/hack/save-logs-files.sh
@@ -171,7 +171,7 @@ for ns in ${namespaces_list[@]+"${namespaces_list[@]}"}; do
     # save the non-certificates configmaps
     for cm in $(kubectl get cm -n $ns -o=jsonpath='{.items[*].metadata.name}'); do
         if [[ ! "$cm" == *.crt ]]; then
-            cm_data=$(kubectl get cm $cm -n $ns -o=jsonpath='{.data}')s
+            cm_data=$(kubectl get cm $cm -n $ns -o=jsonpath='{.data}')
             prefix=$ns--$cm
             echo -e "$prefix:\n$cm_data\n" >> $dirname_logs/configmaps.txt
         fi

--- a/hack/save-logs-files.sh
+++ b/hack/save-logs-files.sh
@@ -136,7 +136,7 @@ dirname_logs_by_container=$dirname_logs/logs_by_container
 mkdir $dirname_logs_by_container
 dirname_not_ready_pods=$dirname_logs/describe_not_ready_pods
 mkdir $dirname_not_ready_pods
-dirname_modules=$dirname_logs/fybrik_modules
+dirname_modules=$dirname_logs/fybrikmodules
 mkdir $dirname_modules
 
 is_found_fybrik_application_yaml=0
@@ -153,7 +153,7 @@ if [[ ! -z $fybrik_application_uuid ]]; then
 else
     if [[ ! -z $fybrik_application_name ]]; then
         # only application flag is used
-        kubectl get fybrikapplication $fybrik_application_name -n $fybrik_application_ns -o=yaml &> $dirname_logs/fybrik_application_$fybrik_application_ns--$fybrik_application_name.yaml
+        kubectl get fybrikapplication $fybrik_application_name -n $fybrik_application_ns -o=yaml &> $dirname_logs/fybrikapplication_$fybrik_application_ns--$fybrik_application_name.yaml
         is_found_fybrik_application_yaml=1
         fybrik_application_uuid=$(kubectl get fybrikapplication $fybrik_application_name -n $fybrik_application_ns -o=jsonpath='{.metadata.uid}')
     fi
@@ -192,7 +192,7 @@ for ns in ${namespaces_list[@]}; do
     if [[ ! -z fybrik_application_uuid ]] && [[ is_found_fybrik_application_yaml -eq 0 ]]; then
         for fybrik_application in $(kubectl get fybrikapplications -n $ns -o=jsonpath='{.items[*].metadata.name}'); do
             if [[ $(kubectl get fybrikapplication $fybrik_application -n $ns -o=jsonpath='{.metadata.uid}') == $fybrik_application_uuid ]]; then
-                kubectl get fybrikapplication $fybrik_application -n $ns -o=yaml &> $dirname_logs/fybrik_application_$ns--$fybrik_application.yaml
+                kubectl get fybrikapplication $fybrik_application -n $ns -o=yaml &> $dirname_logs/fybrikapplication_$ns--$fybrik_application.yaml
                 is_found_fybrik_application_yaml=1
             fi
         done


### PR DESCRIPTION
Made adaptations so the script will run on macOS (by changing several bash commands to make the script compatible across different shell versions). Tested the script on the mac with Apple chip.
Also made several improvements: 
* Check if pod is ready or not, and save 'describe' output if not.
* Create another logs file filtered by only log level of warn or error.
* Save all deployed modules in a dedicated subdirectory.
* Improve code readability with variables for files paths.
* Match terms spelling to the kubernetes way (the CRDs).

Closes #2049 