### PR TITLE
New option to disable validation webhooks.

### DIFF
--- a/charts/fybrik/templates/manager-deployment.yaml
+++ b/charts/fybrik/templates/manager-deployment.yaml
@@ -112,7 +112,7 @@ spec:
             - name: DATA_DIR
               value: {{ include "fybrik.getDataDir" . }}
             - name: ENABLE_WEBHOOKS
-            {{- if .Values.clusterScoped }} 
+            {{- if and .Values.clusterScoped .Values.validationWebhookEnabled }}
               value: "true"
             {{- else }}
               value: "false"
@@ -145,7 +145,7 @@ spec:
             - name: LOCAL_CHARTS_DIR
               value: {{ include "fybrik.localChartsMountPath" . }}
             {{- end }}
-          {{- if .Values.clusterScoped }} 
+          {{- if and .Values.clusterScoped .Values.validationWebhookEnabled }}
           ports:
             - containerPort: 9443
               name: webhook-server
@@ -164,7 +164,7 @@ spec:
           volumeMounts:
             - name: data
               mountPath: {{ include "fybrik.getDataDir" . }}
-           {{- if .Values.clusterScoped }}
+           {{- if and .Values.clusterScoped .Values.validationWebhookEnabled }}
             - mountPath: {{ include "fybrik.getDataSubdir" (tuple "k8s-webhook-server" ) }}
               name: webhook-cert
               readOnly: true
@@ -197,7 +197,7 @@ spec:
             {{- toYaml .Values.manager.resources | nindent 12 }}
       terminationGracePeriodSeconds: 10
       volumes:
-        {{- if .Values.clusterScoped }}
+        {{- if and .Values.clusterScoped .Values.validationWebhookEnabled }}
         - name: webhook-cert
           secret:
             defaultMode: 420

--- a/charts/fybrik/templates/webhook-certificates.yaml
+++ b/charts/fybrik/templates/webhook-certificates.yaml
@@ -1,5 +1,5 @@
 {{- if include "fybrik.isEnabled" (tuple .Values.manager.enabled (or .Values.coordinator.enabled .Values.worker.enabled)) }}
-{{- if .Values.clusterScoped }}
+{{- if and .Values.clusterScoped .Values.validationWebhookEnabled }}
 apiVersion: {{ include "fybrik.certManagerApiVersion" . }}
 kind: Issuer
 metadata:

--- a/charts/fybrik/templates/webhook-configs.yaml
+++ b/charts/fybrik/templates/webhook-configs.yaml
@@ -1,5 +1,5 @@
 {{- if include "fybrik.isEnabled" (tuple .Values.manager.enabled (or .Values.coordinator.enabled .Values.worker.enabled)) }}
-{{- if .Values.clusterScoped }}
+{{- if and .Values.clusterScoped .Values.validationWebhookEnabled }}
 {{ tpl ( .Files.Get "files/webhook-configs.yaml" ) . }}
 {{- end }}
 {{- end }}

--- a/charts/fybrik/templates/webhook-service.yaml
+++ b/charts/fybrik/templates/webhook-service.yaml
@@ -1,5 +1,5 @@
 {{- if include "fybrik.isEnabled" (tuple .Values.manager.enabled (or .Values.coordinator.enabled .Values.worker.enabled)) }}
-{{- if .Values.clusterScoped }}
+{{- if and .Values.clusterScoped .Values.validationWebhookEnabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/fybrik/values.yaml
+++ b/charts/fybrik/values.yaml
@@ -35,6 +35,9 @@ internalCRsNamespace: ""
 # Otherwise, the namespace must already exist.
 adminCRsNamespace: ""
 
+# If true validation webhooks are enabled. Otherwise the webhooks are disabled.
+validationWebhookEnabled: true
+
 # Taxonomy file for taxonomy ConfigMap
 taxonomyOverride: ""
 


### PR DESCRIPTION
This PR adds an option to disable validation webhooks. 
The need was raised while implementing [Argo CD as a multi-cluster manager](https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/3188) due to an [open issue](https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/3188) in Argo CD which causes cert-manager related resources in Fybrik deployment, such as selfsigned-issuer , to be generated with a wrong cert-manager version.
Thanks to @shlomitk1 for suggesting this option.